### PR TITLE
Fix Logo Sizing on Sponsors/Partners/Support Providers

### DIFF
--- a/app/[locale]/about/partners/page.tsx
+++ b/app/[locale]/about/partners/page.tsx
@@ -5,7 +5,6 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import Image from "next/image";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 
 export const metadata: Metadata = {
   title: "Partners - Rocky Linux",
@@ -50,7 +49,7 @@ const PartnersPage = () => {
                     ) : (
                       <Image
                         alt={partner.name}
-                        className="h-32 w-fit p-10 object-fit pointer-events-none"
+                        className="h-32 w-auto p-10 object-fit pointer-events-none"
                         height={1000}
                         src={partner.src || ""}
                         width={1000}

--- a/app/[locale]/about/sponsors/page.tsx
+++ b/app/[locale]/about/sponsors/page.tsx
@@ -53,7 +53,7 @@ const SponsorsPage = () => {
                     ) : (
                       <Image
                         alt={sponsor.name}
-                        className="h-32 w-fit p-10 object-fit pointer-events-none"
+                        className="h-32 w-auto p-10 object-fit pointer-events-none"
                         height={1000}
                         src={sponsor.src || ""}
                         width={1000}

--- a/app/[locale]/support/support-providers/page.tsx
+++ b/app/[locale]/support/support-providers/page.tsx
@@ -51,7 +51,7 @@ const SupportProvidersPage = () => {
                     ) : (
                       <Image
                         alt={sponsor.name}
-                        className="h-32 w-fit p-10 object-fit pointer-events-none"
+                        className="h-32 w-auto p-10 object-fit pointer-events-none"
                         height={1000}
                         src={sponsor.src || ""}
                         width={1000}


### PR DESCRIPTION
Some browsers (namely those using WebKit) were having issues with the sizing of the logos. This PR includes changes that will resolve the issue.