### PR TITLE
Add redirect for old cloud images

### DIFF
--- a/e2e/Homepage.spec.ts
+++ b/e2e/Homepage.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { expectDownloadPage } from "./utils/PageUtils";
 
 test.describe("Core Rocky Brand", () => {
   test("has title", async ({ page }) => {
@@ -9,13 +10,8 @@ test.describe("Core Rocky Brand", () => {
   });
 });
 
-test.describe("Downloads Flow", () => {
-  test("has two download buttons on desktop", async ({ page, isMobile }) => {
-    const verifyDownloadPage = async () => {
-      await expect(page).toHaveURL(/\/download/);
-      await expect(page).toHaveTitle(/Download - Rocky Linux/);
-    };
-
+test.describe("Home Page Downloads Flow", () => {
+  test("has download buttons", async ({ page, isMobile }) => {
     await page.goto("/");
 
     // Check that we have a download button in the navigation on desktop.
@@ -28,7 +24,7 @@ test.describe("Downloads Flow", () => {
 
       await navDownloadButton.click();
 
-      await verifyDownloadPage();
+      await expectDownloadPage(page);
 
       await page.goBack();
     }
@@ -43,6 +39,6 @@ test.describe("Downloads Flow", () => {
 
     await heroDownloadButton.click();
 
-    await verifyDownloadPage();
+    await expectDownloadPage(page);
   });
 });

--- a/e2e/Redirects.spec.ts
+++ b/e2e/Redirects.spec.ts
@@ -1,0 +1,10 @@
+import { test } from "@playwright/test";
+import { expectDownloadPage } from "./utils/PageUtils";
+
+test.describe("Website Redirects", () => {
+  test("redirects old /cloud-images to /download", async ({ page }) => {
+    await page.goto("/cloud-images");
+
+    await expectDownloadPage(page);
+  });
+});

--- a/e2e/utils/PageUtils.ts
+++ b/e2e/utils/PageUtils.ts
@@ -1,0 +1,6 @@
+import { expect, type Page } from "@playwright/test";
+
+export const expectDownloadPage = async (page: Page) => {
+  await expect(page).toHaveURL(/\/download/);
+  await expect(page).toHaveTitle(/Download - Rocky Linux/);
+};

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,15 @@ const nextConfig = {
   images: {
     domains: ["www.rockylinux.org", "rockylinux.org"],
   },
+  async redirects() {
+    return [
+      {
+        source: "/cloud-images",
+        destination: "/download",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 module.exports = withNextIntl(nextConfig);


### PR DESCRIPTION
This addresses #24 where we want to redirect `/cloud-images` to `/download`