### PR TITLE
Add redirect for /trademark to /legal/trademarks

### DIFF
--- a/e2e/Redirects.spec.ts
+++ b/e2e/Redirects.spec.ts
@@ -1,10 +1,19 @@
 import { test } from "@playwright/test";
-import { expectDownloadPage } from "./utils/PageUtils";
+import {
+  expectDownloadPage,
+  expectTrademarkUsagePage,
+} from "./utils/PageUtils";
 
 test.describe("Website Redirects", () => {
   test("redirects old /cloud-images to /download", async ({ page }) => {
     await page.goto("/cloud-images");
 
     await expectDownloadPage(page);
+  });
+  // /trademark redirects to /legal/trademarks
+  test("redirects old /trademark to /legal/trademarks", async ({ page }) => {
+    await page.goto("/trademark");
+
+    await expectTrademarkUsagePage(page);
   });
 });

--- a/e2e/Redirects.spec.ts
+++ b/e2e/Redirects.spec.ts
@@ -10,7 +10,6 @@ test.describe("Website Redirects", () => {
 
     await expectDownloadPage(page);
   });
-  // /trademark redirects to /legal/trademarks
   test("redirects old /trademark to /legal/trademarks", async ({ page }) => {
     await page.goto("/trademark");
 

--- a/e2e/utils/PageUtils.ts
+++ b/e2e/utils/PageUtils.ts
@@ -4,3 +4,8 @@ export const expectDownloadPage = async (page: Page) => {
   await expect(page).toHaveURL(/\/download/);
   await expect(page).toHaveTitle(/Download - Rocky Linux/);
 };
+
+export const expectTrademarkUsagePage = async (page: Page) => {
+  await expect(page).toHaveURL(/\/legal\/trademarks/);
+  await expect(page).toHaveTitle(/Trademark Usage - Rocky Linux/);
+};

--- a/next.config.js
+++ b/next.config.js
@@ -19,6 +19,11 @@ const nextConfig = {
         destination: "/download",
         permanent: true,
       },
+      {
+        source: "/trademark",
+        destination: "/legal/trademarks",
+        permanent: true,
+      },
     ];
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,14 @@ const withNextIntl = require("next-intl/plugin")("./i18n.ts");
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ["www.rockylinux.org", "rockylinux.org"],
+    remotePatterns: [
+      {
+        hostname: "www.rockylinux.org",
+      },
+      {
+        hostname: "rockylinux.org",
+      },
+    ],
   },
   async redirects() {
     return [


### PR DESCRIPTION
Addresses /trademark redirection outlined in #27 