### PR TITLE
Fix workstation images version on picking rocky 8

### DIFF
--- a/app/[locale]/download/page.tsx
+++ b/app/[locale]/download/page.tsx
@@ -274,7 +274,7 @@ const DownloadPage = () => {
                       {
                         versionName: `${t("cards.defaultImages.x86_64.r8.versionName")}`,
                         versionId: "rocky-8",
-                        currentVersion: "v9.3",
+                        currentVersion: "v8.9",
                         plannedEol: `${t("cards.defaultImages.x86_64.r8.plannedEol")}`,
                         downloadOptions: [
                           {


### PR DESCRIPTION
fix workstation images version on picking rocky 8