### PR TITLE
Fix workstation image link for rocky linux 8

### DIFF
--- a/app/[locale]/download/page.tsx
+++ b/app/[locale]/download/page.tsx
@@ -279,7 +279,7 @@ const DownloadPage = () => {
                         downloadOptions: [
                           {
                             label: `${t("cards.liveImages.downloadOptions.gnome")}`,
-                            link: "https://download.rockylinux.org/pub/rocky/8/Live/x86_64/Rocky-Workstation-8-x86_64-latest.iso",
+                            link: "https://dl.rockylinux.org/pub/rocky/8/Live/x86_64/Rocky-8-Workstation-x86_64-latest.iso",
                           },
                           {
                             label: `${t("cards.liveImages.downloadOptions.gnomeLite")}`,


### PR DESCRIPTION
fix workstation image link for rocky linux 8