### PR TITLE
Fix Hacktoberfest links to rockylinux resources

### DIFF
--- a/news/2024-10-07-hacktoberfest.md
+++ b/news/2024-10-07-hacktoberfest.md
@@ -9,7 +9,7 @@ author: "Krista Burdine, Community Team Lead"
 
 It’s October, which means we are in the season of Hacktoberfest! Hosted by [Digital Ocean](https://www.digitalocean.com/), this month-long event supports open source community health by encouraging contributions to GitHub- and GitLab-hosted public repositories. We celebrate the vision that led to this program. Last year more than 98,000 people participated; it’s exciting to think of the greater open source community receiving potentially almost 400,000 additions, modifications, and upgrades to existing content!
 
-If you are a Hacktober participant, looking for a specific project to support, [Rocky Linux](rockylinux.org) is hosted on GitHub! This means you can receive credit for contributing to our project. We would be happy to have you.
+If you are a Hacktober participant, looking for a specific project to support, [Rocky Linux](https://rockylinux.org) is hosted on GitHub! This means you can receive credit for contributing to our project. We would be happy to have you.
 
 You’ll find a variety of open issues that outline needs from the Documentation, Web, and Wiki (community) repositories. These needs include desired tutorials; a new feature for our website; using a template to initialize document reports for past events; and some opportunities for social media posting.
 
@@ -22,6 +22,6 @@ The relevant repos and issues are tagged, but original ideas are also welcome. I
 3. Visit our GitHub [repositories](https://github.com/rocky-linux), specifically [documentation](https://github.com/rocky-linux/documentation), [ rockylinux.org](https://github.com/rocky-linux/rockylinux.org), and [wiki.rockylinux.org](https://github.com/rocky-linux/wiki.rockylinux.org) and check out the open issues labeled #hacktoberfest.
 4. Check out the contribution guide for the repo you want to work in, and then choose an issue and run with it.
 
-First time contributing to the Rocky Linux project? Get to know us via our [chat server](chat.rockylinux.org). 
+First time contributing to the Rocky Linux project? Get to know us via our [chat server](https://chat.rockylinux.org).
 
 Will you be part of the event this year? We invite you to check out our wish list! Have a great October.


### PR DESCRIPTION
Fixes for the next page: https://rockylinux.org/news/2024-10-07-hacktoberfest