### PR TITLE
Update current rpi version to v9.2 (Beta) on the downloads page

### DIFF
--- a/app/[locale]/download/page.tsx
+++ b/app/[locale]/download/page.tsx
@@ -544,7 +544,7 @@ const DownloadPage = () => {
                       {
                         versionName: `${t("cards.defaultImages.x86_64.r9.versionName")}`,
                         versionId: "rocky-9",
-                        currentVersion: "v9.5",
+                        currentVersion: "v9.2 (Beta)",
                         plannedEol: `${t("cards.defaultImages.x86_64.r9.plannedEol")}`,
                         downloadOptions: [
                           {


### PR DESCRIPTION
This pull request includes a small change to the `app/[locale]/download/page.tsx` file. The change updates the `currentVersion` of the `versionId` "rocky-9" from "v9.5" to "v9.2 (Beta)" for Raspberry Pi images to reflect the current version and beta status of the download.

* `app/[locale]/download/page.tsx`: Updated `currentVersion` of `versionId` "rocky-9" from "v9.5" to "v9.2 (Beta)". ([app/[locale]/download/page.tsxL547-R547](diffhunk://#diff-0147ff569755f73a418a60fe152d6428b369352aad4d74c4f026146204c9a7c5L547-R547))