### PR TITLE
feat: add redirect for /keys to /resources/gpg-key-info and update test cases

### DIFF
--- a/__tests__/next.config.test.ts
+++ b/__tests__/next.config.test.ts
@@ -37,7 +37,7 @@ describe("next.config", () => {
     });
 
     it("should have the correct number of redirects", async () => {
-      expect(redirects).toHaveLength(12);
+      expect(redirects).toHaveLength(13);
     });
 
     it("should have the community-charter redirect", async () => {
@@ -132,6 +132,14 @@ describe("next.config", () => {
       expect(redirects).toContainEqual<Redirect>({
         source: "/news/2024-07-01-rocky-linux-9-cve-2024-6378-regression",
         destination: "/news/2024-07-01-openssh-sigalrm-regression",
+        permanent: true,
+      });
+    });
+
+    it("should redirect keys to the correct location", async () => {
+      expect(redirects).toContainEqual<Redirect>({
+        source: "/keys",
+        destination: "/resources/gpg-key-info",
         permanent: true,
       });
     });

--- a/next.config.js
+++ b/next.config.js
@@ -75,7 +75,12 @@ const nextConfig = {
         source: "/news/2024-07-01-rocky-linux-9-cve-2024-6378-regression",
         destination: "/news/2024-07-01-openssh-sigalrm-regression",
         permanent: true,
-      }
+      },
+      {
+        source: "/keys",
+        destination: "/resources/gpg-key-info",
+        permanent: true,
+      },
     ];
   },
 };


### PR DESCRIPTION
This pull request includes updates to the redirects file and updated tests.

Key changes include:

* Updated the expected number of redirects from 12 to 13 in the test case with a matching test case.
* Added a new redirect to route `/keys` to `/resources/gpg-key-info` as a permanent redirect.