### PR TITLE
Fixing 404s on five pages

### DIFF
--- a/legal/privacy.md
+++ b/legal/privacy.md
@@ -19,7 +19,7 @@ Unless explicitly noted, this Privacy Policy does not cover 3rd party services o
 
 ## What Data Do We Collect and Receive?
 
-In order for us to both provide and maintain our Services, we collect certain information, including through [Fathom](https://usefathom.com) for analytics on our websites. You may view the analytics we collect for this website [here](https://app.usefathom.com/share/qdepahys/website), as well as our documentation website [here](https://app.usefathom.com/share/ktsptdwy/documentation). Depending on your use of the Services, we may collect the following information:
+In order for us to both provide and maintain our Services, we collect certain information, including through [Plausible](https://plausible.io/) for analytics on our websites. You may view the analytics we collect for this website [here](https://plausible.io/rockylinux.org), as well as our documentation website [here](https://plausible.io/docs.rockylinux.org). Depending on your use of the Services, we may collect the following information:
 
 - **Information you provide when you contact us** – for example, when you ask for support, send us questions or comments, or report a problem, we will collect any information you provide to us, at a minimum including your email address, and message. We use this data in connection with answering the queries we receive.
 

--- a/news/2025-03-12-un-open-source-principles.md
+++ b/news/2025-03-12-un-open-source-principles.md
@@ -20,7 +20,7 @@ The UN Open Source Principles are comprised of eight guidelines and provide a fr
 
 The UN and the RESF invite other organizations to join in support of the UN Open Source Principles and in contributing to a future of open, inclusive digital solutions worldwide. To endorse the UN Open Source Principles, [submit your organization’s information here](https://forms.office.com/e/m75hJKPiyv).
 
-[Open Source United](https://www.un.org/digital-emerging-technologies/content/open-source-digital-transformation), a community of practice established by the DTN, works to advance Open Source technologies throughout UN agencies. It promotes collaboration and scalable solutions to support the UN’s digital transformation.
+[Open Source United](https://unite.un.org/news/digital-and-technology-network-facilitating-un-digital-transformation), a community of practice established by the DTN, works to advance Open Source technologies throughout UN agencies. It promotes collaboration and scalable solutions to support the UN’s digital transformation.
 
 The [RESF](https://resf.org), founded in 2020, was created with the mission to ensure the longevity, stewardship, and innovation of enterprise-class open-source software, always maintaining its free availability. The RESF supports [Rocky Linux](https://rockylinux.org), a UN recognized [Digital Public Good](https://www.digitalpublicgoods.net).
 

--- a/news/community-update-december-2021.md
+++ b/news/community-update-december-2021.md
@@ -106,7 +106,7 @@ We need you! The Community Team is seeking volunteers to help us grow community 
 
 - We are working on a UI toolkit which will replace all of the existing Tailwind CSS-based theming across the RESF’s web presence. This is to ensure consistency in design between all Rocky Linux experiences, and will have its debut on the main Rocky Linux website. More sites will follow, but for now it will just be the main website.
 
-- We have implemented Fathom Analytics on both the main website, as well as the Documentation website. Fathom is an open-source, privacy-friendly, cookie-less analytics solution. You can view our analytics publicly at the links below.
+- We have implemented Plausible Analytics on both the main website, as well as the Documentation website. Plausible is an open-source, privacy-friendly, cookie-less analytics solution. You can view our analytics publicly at the links below.
 
 - [Main Website Analytics](https://plausible.io/rockylinux.org)
 

--- a/news/community-update-december-2021.md
+++ b/news/community-update-december-2021.md
@@ -108,9 +108,9 @@ We need you! The Community Team is seeking volunteers to help us grow community 
 
 - We have implemented Fathom Analytics on both the main website, as well as the Documentation website. Fathom is an open-source, privacy-friendly, cookie-less analytics solution. You can view our analytics publicly at the links below.
 
-- [Main Website Analytics](https://app.usefathom.com/share/qdepahys/website/)
+- [Main Website Analytics](https://plausible.io/rockylinux.org)
 
-- [Documentation Website Analytics](https://app.usefathom.com/share/ktsptdwy/documentation/)
+- [Documentation Website Analytics](https://plausible.io/docs.rockylinux.org)
 
 ## Special Interest Groups
 

--- a/news/community-update-november-2024.md
+++ b/news/community-update-november-2024.md
@@ -4,12 +4,11 @@ date: "2024-11-12"
 author: "Krista Burdine, Community Team Lead"
 ---
 
-
 # Community Update: 9.5 Release Coming Soon, RISC-V, More | November 2024
 
 ## 9.5 Release Underway
 
-It’s that time again! The Rocky Linux team is working through the Release Playbook for Version 9.5. Official release and notes expected as soon as all images pass testing procedures. This is a great time to connect with the Testing Team at [chat.rockylinux.org](https://chat.rockylinux.org) and see how you can help. 
+It’s that time again! The Rocky Linux team is working through the Release Playbook for Version 9.5. Official release and notes expected as soon as all images pass testing procedures. This is a great time to connect with the Testing Team at [chat.rockylinux.org](https://chat.rockylinux.org) and see how you can help.
 
 ## RISC-V Collaboration
 
@@ -21,12 +20,11 @@ To be part of this effort, join [Mattermost](https://chat.rockylinux.org), find 
 
 ## Elsewhere in the Project
 
-In addition to the current release cycle and the RISC-V project, fresh ideas continue to drive progress in the Rocky Linux Project. 
+In addition to the current release cycle and the RISC-V project, fresh ideas continue to drive progress in the Rocky Linux Project.
 
 ### Documentation
 
-The Documentation Team recently held a special initiative, [Rocky Summer of Docs](https://docs.rockylinux.org/guides/rsod/) (RSOD) to grow our contributorship and populate a new category of documentation for [Desktop and Gaming](https://docs.rockylinux.org/desktop/). In October they participated in another initiative, Hacktoberfest, which brought in more new contributors through GitHub and helped us add some additional tutorials. Thanks to everyone who participated in both events!
-
+The Documentation Team recently held a special initiative, Rocky Summer of Docs (RSOD) to grow our contributorship and populate a new category of documentation for [Desktop and Gaming](https://docs.rockylinux.org/desktop/). In October they participated in another initiative, Hacktoberfest, which brought in more new contributors through GitHub and helped us add some additional tutorials. Thanks to everyone who participated in both events!
 
 ### Community
 
@@ -34,16 +32,14 @@ The Community Team has been busy traveling around the US and internationally in 
 
 #### OLF Conference (Columbus, Ohio, USA)
 
-This weekend, Rocky Linux will be at Ohio Linux Fest. Two of our community members, Maxine Hayes and Anthony Navarro, will be [speakers](https://olfconference.org/speakers/)! Be sure to stop by the Rocky Linux table for stickers and tees. 
+This weekend, Rocky Linux will be at Ohio Linux Fest. Two of our community members, Maxine Hayes and Anthony Navarro, will be [speakers](https://olfconference.org/speakers/)! Be sure to stop by the Rocky Linux table for stickers and tees.
 
 #### SuperComputing ‘24 (Atlanta, GA, USA)
 
-Rocky Linux is a favorite OS choice in the HPC community! Will you be at SC24 in Atlanta next week, November 18-22? Look for Rocky Linux community members sharing space at booth #4131, co-located with Founding RESF Sponsor CIQ. If your enterprise runs on Rocky Linux, community representatives would love to connect, create a profile of your use-case, and discuss collaboration opportunities. 
+Rocky Linux is a favorite OS choice in the HPC community! Will you be at SC24 in Atlanta next week, November 18-22? Look for Rocky Linux community members sharing space at booth #4131, co-located with Founding RESF Sponsor CIQ. If your enterprise runs on Rocky Linux, community representatives would love to connect, create a profile of your use-case, and discuss collaboration opportunities.
 
 ## We love our Community, Sponsors, and Partners
 
 With the Rocky Linux annual report and biennial RESF Board elections coming up in the next 60 days, you can expect more information soon on the State of the Project and 2025 Roadmaps for the Rocky Linux teams and SIGs. As always, we appreciate the support of our community, sponsors, and partners.
 
-For further inquiries, please reach out to [hello@rockylinux.org](mailto:hello@rockylinux.org). 
-
-  
+For further inquiries, please reach out to [hello@rockylinux.org](mailto:hello@rockylinux.org).

--- a/news/resf-charter-2022-11-11.md
+++ b/news/resf-charter-2022-11-11.md
@@ -4,12 +4,12 @@ date: "2022-11-11"
 author: "Rocky Enterprise Software Foundation"
 ---
 
-The Rocky Enterprise Software Foundation (RESF) today published its charter and bylaws, documenting the organization’s governing structure and rules for hosting open source projects, including its namesake project, [Rocky Linux](https://rockylinux.org/). The charter and bylaws also describe the RESF vision to create and nurture a community of individuals and organizations that are committed to ensuring the longevity, stewardship and innovation of enterprise-grade open source software that is always freely available.
+The Rocky Enterprise Software Foundation (RESF) today published its charter and bylaws, documenting the organization’s governing structure and rules for hosting open source projects, including its namesake project, [Rocky Linux][1]. The charter and bylaws also describe the RESF vision to create and nurture a community of individuals and organizations that are committed to ensuring the longevity, stewardship and innovation of enterprise-grade open source software that is always freely available.
 
 ### RESF Resources
 
-- [Charter and Bylaws](https://rockylinux.org/bylaws-charter)
-- [Frequently Asked Questions](https://rockylinux.org/resf-faq)
+- [Charter and Bylaws][2]
+- [Frequently Asked Questions][3]
 
 Adopted on November 9, the new RESF charter and bylaws were voted on by the initial charter member group of 30 RESF and Rocky Linux contributors. The vote was procedurally ratified by Gregory Kurtzer, who filed the original paperwork to establish the RESF as a Delaware Public Benefits Corporation (PBC). By ratifying the new bylaws and charter, Kurtzer legally has turned over the control of the RESF to the structure defined within those documents, a structure designed to ensure community control while specifically enabling enterprise use-cases and the participation of vendors and other commercial entities.
 
@@ -25,9 +25,9 @@ Although avoiding singular corporate control is integral to the governing princi
 - Every project gets a voice within the foundation and is governed by checks and balances. Every project will have a project board, and each project board will have a seat on the foundation board.
 - Each Tier 1 Principal Sponsor is granted a single advisory seat. The advisory committees do not have the ability to vote on decisions within the RESF or projects; they exist primarily to provide guidance and collaboration.
 
-Read the full charter and bylaws of the RESF [here](https://rockylinux.org/bylaws-charter).
+Read the full charter and bylaws of the RESF [here][2].
 
-“The model reflected in the RESF charter and bylaws represents the model behind Rocky Linux and one of the major reasons Rocky Linux has so quickly become the leading successor to CentOS,” said Kurtzer, citing [EPEL statistics](https://ciq.com/tracking-rocky-linux-growth-using-fedoras-epel-project/) and [Hyperion Research data](https://hyperionresearch.com/wp-content/uploads/2022/11/Hyperion-Research-SC22-HPC-Market_Combined-1.pdf) (slide 63). “Rocky Linux benefits not only from an active community but also from strong commercial support. A number of well known organizations provide financial support and value-add contributions as sponsors. Additionally many companies provide representatives who are active project contributors, and many of our community members offer their own commercial products and services based on Rocky Linux.”
+“The model reflected in the RESF charter and bylaws represents the model behind Rocky Linux and one of the major reasons Rocky Linux has so quickly become the leading successor to CentOS,” said Kurtzer, citing [EPEL statistics][4] and [Hyperion Research data][5] (slide 63). “Rocky Linux benefits not only from an active community but also from strong commercial support. A number of well known organizations provide financial support and value-add contributions as sponsors. Additionally many companies provide representatives who are active project contributors, and many of our community members offer their own commercial products and services based on Rocky Linux.”
 
 “We, the RESF charter members, want to create a place where other projects can take advantage of this model as well,” said Benjamin Agner, deputy CISO at Unum Group and a co-lead of the security and compliance team for Rocky Linux and the RESF. “So, we’ve worked hard to design a protective structure—based on principles of accountability and transparency—to balance corporate interests and needs with those of the community. We’re confident this structure will support growth and deliver stability and longevity as well.”
 
@@ -37,4 +37,11 @@ The RESF welcomes any open source projects that need a neutral ground to operate
 
 ## About the RESF
 
-The Rocky Enterprise Software Foundation (RESF) exists to organize open-source communities comprising enterprise, research, academia, individuals and other institutions to collaborate on building and maintaining the open source tools that these organizations need. The vision of the RESF is to create and nurture a community that is committed to ensuring the longevity, stewardship and innovation of enterprise-grade open source software that is always freely available. Organizations interested in becoming a sponsor and learning about the multiple benefits of RESF sponsorship should contact sponsor@resf.org. Individuals interested in becoming a member of the RESF must first be active in an RESF project; visit the [Rocky Wiki](https://wiki.rockylinux.org/contributing/#signing-agreements) to learn more.
+The Rocky Enterprise Software Foundation (RESF) exists to organize open-source communities comprising enterprise, research, academia, individuals and other institutions to collaborate on building and maintaining the open source tools that these organizations need. The vision of the RESF is to create and nurture a community that is committed to ensuring the longevity, stewardship and innovation of enterprise-grade open source software that is always freely available. Organizations interested in becoming a sponsor and learning about the multiple benefits of RESF sponsorship should contact sponsor@resf.org. Individuals interested in becoming a member of the RESF must first be active in an RESF project; visit the [Rocky Wiki][6] to learn more.
+
+[1]: https://rockylinux.org "Rocky Linux"
+[2]: https://www.resf.org/about "RESF Charter and Bylaws"
+[3]: https://www.resf.org/faq "RESF Frequently Asked Questions"
+[4]: https://ciq.com/blog/tracking-rocky-linux-growth-using-fedoras-epel-project/ "Tracking Rocky Linux Growth Using Fedora’s EPEL Project"
+[5]: https://hyperionresearch.com/wp-content/uploads/2022/11/Hyperion-Research-SC22-HPC-Market_Combined-1.pdf
+[6]: https://wiki.rockylinux.org/contributing/#signing-agreements "Rocky Wiki: Contributing"


### PR DESCRIPTION
privacy.md — plausible.io swapped in for usefathom.com URLs
news/2025-03-12-un-open-source-principles.md — UN site structure has changed a lot; updated to best possible match
news/community-update-december-2021.md — plausible.io swapped in for usefathom.com URLs
news/community-update-november-2024.md — removed dead link to RSOD
news/resf-charter-2022-11-11.md — Swapped links to Charter and FAQ to the resf.org/about page