### PR TITLE
Enhance GitHub workflows to trigger on merge_group events for Playwright and Validate tests

### DIFF
--- a/.github/workflows/Validate.yml
+++ b/.github/workflows/Validate.yml
@@ -3,6 +3,7 @@ name: Unit Tests and Linting
 on:
   push:
   pull_request:
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,6 +2,7 @@ name: Playwright Tests
 on:
   push:
   pull_request:
+  merge_group:
 jobs:
   e2e-tests:
     timeout-minutes: 60


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to add the `merge_group` event trigger for both unit tests and Playwright tests.

Changes to GitHub Actions workflows:

* [`.github/workflows/Validate.yml`](diffhunk://#diff-1dd3b183b8a44355cb587edf8bf0ae487e47caee670ac790c7b779a5cd790b32R6): Added the `merge_group` event trigger to the workflow for unit tests and linting.
* [`.github/workflows/playwright.yml`](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3R5): Added the `merge_group` event trigger to the workflow for Playwright tests.