### PR TITLE
Update rocky-linux-9-6-ga-release.md with @grayeul name

### DIFF
--- a/news/rocky-linux-9-6-ga-release.md
+++ b/news/rocky-linux-9-6-ga-release.md
@@ -72,7 +72,7 @@ Special recognition to these contributors for their work on this release:
 - Chris Stackpole
 - Fredrik Nystrom
 - Gabriel Graves
-- @grayeul
+- Bob Robison
 - Louis Abel
 - Lukas Magauer
 - Michael Kinder


### PR DESCRIPTION
@grayeul requested that his name be in place of his Mattermost handle. This PR fixes that.