### PR TITLE
Fixes #115: Broken Internal Links

### DIFF
--- a/news/community-update-february-2021.md
+++ b/news/community-update-february-2021.md
@@ -47,7 +47,7 @@ Responsibility to the community is critical to our success. To that end, we’ve
 
 ### FAQ
 
-We’ve expanded upon and published a [FAQ](https://rockylinux.org/faq/) which addresses a number of questions that we’ve received. Questions such as “If Rocky Linux is just a respin of RHEL, what’s taking so long for a release candidate?” and “If you’re not just repackaging RHEL, then what exactly are you doing?” and more are all addressed. We will be adding to the FAQ over time based on questions the community surfaces.
+We’ve expanded upon and published a [FAQ](https://wiki.rockylinux.org/archive/legacy/faq/) which addresses a number of questions that we’ve received. Questions such as “If Rocky Linux is just a respin of RHEL, what’s taking so long for a release candidate?” and “If you’re not just repackaging RHEL, then what exactly are you doing?” and more are all addressed. We will be adding to the FAQ over time based on questions the community surfaces.
 
 ### Mattermost
 

--- a/news/community-update-june-2021.md
+++ b/news/community-update-june-2021.md
@@ -28,7 +28,7 @@ Details on how to find and launch Rocky Linux on Azure will be soon forthcoming.
 
 ## Leadership
 
-We’ve received a few questions from the community about the structure of the RESF, and while this information has always been available on our website, we made updates for clarity. Summarized, the Rocky Enterprise Software Foundation (RESF) is a Public Benefit Corporation (PBC) formed in Delaware (file number 4429978), backed by a board of advisors with access control policies that utilize the principle of least privilege and separation of duty to ensure that no action can be taken unilaterally (not even by the legal owner, Gregory Kurtzer). For more information, see our [Organizational Structure](https://rockylinux.org/organizational-structure/).
+We’ve received a few questions from the community about the structure of the RESF, and while this information has always been available on our website, we made updates for clarity. Summarized, the Rocky Enterprise Software Foundation (RESF) is a Public Benefit Corporation (PBC) formed in Delaware (file number 4429978), backed by a board of advisors with access control policies that utilize the principle of least privilege and separation of duty to ensure that no action can be taken unilaterally (not even by the legal owner, Gregory Kurtzer). For more information, see our [Organizational Structure](https://www.resf.org/about).
 
 ## Documentation
 

--- a/news/happy-birthday-rocky.md
+++ b/news/happy-birthday-rocky.md
@@ -28,4 +28,4 @@ More recently, the creation of the Open Enterprise Linux Association (OpenELA) h
 
 For three years the core Rocky Linux team and an army of contributors have held fast to their commitment to excellence. The adoption rates of Rocky Linux continue to rise. What does the next chapter hold? You are invited to come along for the ride!
 
-Check out the project at [rockylinux.org](rockylinux.org). Find community at [chat.rockylinux.org](chat.rockylinux.org), get troubleshooting help at [forums.rockylinux.org](forums.rockylinux.org), peruse the documentation at [docs.rockylinux.org](docs.rockylinux.org).
+Check out the project at [rockylinux.org](https://rockylinux.org). Find community at [chat.rockylinux.org](https://chat.rockylinux.org), get troubleshooting help at [forums.rockylinux.org](https://forums.rockylinux.org), peruse the documentation at [docs.rockylinux.org](https://docs.rockylinux.org).

--- a/news/rocky-linux-8-4-rc1-release.md
+++ b/news/rocky-linux-8-4-rc1-release.md
@@ -33,7 +33,7 @@ No, we plan to iron out any reported bugs in Rocky Linux 8.4 RC1 and then move s
 
 There will not be a stable release of Rocky Linux 8.3. The first stable release of Rocky Linux will be 8.4.
 
-More FAQ can be found on our website [here](https://rockylinux.org/faq/).
+More FAQ can be found on our website [here](https://wiki.rockylinux.org/archive/legacy/faq/).
 
 ---
 


### PR DESCRIPTION
Found a few broken internal links on old news entries. Some of the pages, like the FAQ, did not have a clear successor/new location, so put the closest option I could find.

The rest of the changes were either fixing the links (adding `https://`) or replacing with the best new link based on context.