### PR TITLE
Remove un-published download links and update RPI link

### DIFF
--- a/data/downloads.json
+++ b/data/downloads.json
@@ -23,7 +23,7 @@
             "liveImages": {
               "gnome": "https://dl.rockylinux.org/pub/rocky/10/live/x86_64/Rocky-10-Workstation-x86_64-latest.iso",
               "gnomeLite": "https://dl.rockylinux.org/pub/rocky/10/live/x86_64/Rocky-10-Workstation-Lite-x86_64-latest.iso",
-              "kde": "https://dl.rockylinux.org/pub/rocky/10/live/x86_64/Rocky-10-KDE-x86_64-latest.iso",
+              "kde": "https://dl.rockylinux.org/pub/rocky/10/live/x86_64/Rocky-10-KDE-x86_64-latest.iso"
             },
             "wslImages": {
               "download": "https://dl.rockylinux.org/pub/rocky/10/images/x86_64/Rocky-10-WSL-Base.latest.x86_64.wsl"

--- a/data/downloads.json
+++ b/data/downloads.json
@@ -24,9 +24,6 @@
               "gnome": "https://dl.rockylinux.org/pub/rocky/10/live/x86_64/Rocky-10-Workstation-x86_64-latest.iso",
               "gnomeLite": "https://dl.rockylinux.org/pub/rocky/10/live/x86_64/Rocky-10-Workstation-Lite-x86_64-latest.iso",
               "kde": "https://dl.rockylinux.org/pub/rocky/10/live/x86_64/Rocky-10-KDE-x86_64-latest.iso",
-              "xfce": "https://dl.rockylinux.org/pub/rocky/10/live/x86_64/Rocky-10-XFCE-x86_64-latest.iso",
-              "mate": "https://dl.rockylinux.org/pub/rocky/10/live/x86_64/Rocky-10-MATE-x86_64-latest.iso",
-              "cinnamon": "https://dl.rockylinux.org/pub/rocky/10/live/x86_64/Rocky-10-Cinnamon-x86_64-latest.iso"
             },
             "wslImages": {
               "download": "https://dl.rockylinux.org/pub/rocky/10/images/x86_64/Rocky-10-WSL-Base.latest.x86_64.wsl"
@@ -159,9 +156,6 @@
               "gnome": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-Workstation-aarch64-latest.iso",
               "gnomeLite": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-Workstation-Lite-aarch64-latest.iso",
               "kde": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-KDE-aarch64-latest.iso",
-              "xfce": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-XFCE-aarch64-latest.iso",
-              "mate": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-MATE-aarch64-latest.iso",
-              "cinnamon": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-Cinnamon-aarch64-latest.iso"
             },
             "rpiImages": {
               "download": "https://dl.rockylinux.org/pub/sig/10/altarch/aarch64/images/RockyLinuxRpi_10-latest.img.xz"

--- a/data/downloads.json
+++ b/data/downloads.json
@@ -155,7 +155,7 @@
             "liveImages": {
               "gnome": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-Workstation-aarch64-latest.iso",
               "gnomeLite": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-Workstation-Lite-aarch64-latest.iso",
-              "kde": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-KDE-aarch64-latest.iso",
+              "kde": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-KDE-aarch64-latest.iso"
             },
             "rpiImages": {
               "download": "https://dl.rockylinux.org/pub/sig/10/altarch/aarch64/images/RockyLinuxRpi_10-latest.img.xz"

--- a/data/downloads.json
+++ b/data/downloads.json
@@ -158,7 +158,7 @@
               "kde": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-KDE-aarch64-latest.iso"
             },
             "rpiImages": {
-              "download": "https://dl.rockylinux.org/pub/sig/10/altarch/aarch64/images/RockyLinuxRpi_10-latest.img.xz"
+              "download": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-SBC-RaspberryPi.latest.aarch64.raw.xz"
             }
           },
           "links": {


### PR DESCRIPTION
This pull request updates the `data/downloads.json` file to streamline the list of available live images for Rocky Linux. The changes remove several desktop environment options for both `x86_64` and `aarch64` architectures, leaving only the KDE option.

Updates to available live images:

* Removed the XFCE, MATE, and Cinnamon live images for the `x86_64` architecture, retaining only the KDE option. (`data/downloads.json`, [data/downloads.jsonL26-R26](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9L26-R26))
* Removed the XFCE, MATE, and Cinnamon live images for the `aarch64` architecture, retaining only the KDE option. (`data/downloads.json`, [data/downloads.jsonL161-R158](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9L161-R158))