### PR TITLE
downloads.json: update RPi Link

### DIFF
--- a/data/downloads.json
+++ b/data/downloads.json
@@ -158,7 +158,7 @@
               "kde": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-KDE-aarch64-latest.iso"
             },
             "rpiImages": {
-              "download": "https://dl.rockylinux.org/pub/sig/10/altarch/aarch64/images/RockyLinuxRpi_10-latest.img.xz"
+              "download": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-SBC-RaspberryPi.latest.aarch64.raw.xz"
             }
           },
           "links": {


### PR DESCRIPTION
This pull request updates the download link for Raspberry Pi images in the `data/downloads.json` file to reflect the new file location and naming convention.

* [`data/downloads.json`](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9L161-R161): Changed the `rpiImages.download` URL to point to the updated location and filename for Raspberry Pi images. The new URL is `https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-SBC-RaspberryPi.latest.aarch64.raw.xz`.