### PR TITLE
Language updates and WSL links

### DIFF
--- a/app/[locale]/download/page.tsx
+++ b/app/[locale]/download/page.tsx
@@ -268,7 +268,7 @@ const DownloadPage = () => {
                           )}
                         />
                       ) : null}
-                      {arch === "x86_64" ? (
+                      {arch === "x86_64" || arch === "aarch64" ? (
                         <DefaultImageCard
                           title={t("cards.wslImages.title")}
                           titleTooltip={false}

--- a/data/downloads.json
+++ b/data/downloads.json
@@ -73,6 +73,9 @@
               "xfce": "https://dl.rockylinux.org/pub/rocky/9/live/x86_64/Rocky-9-XFCE-x86_64-latest.iso",
               "mate": "https://dl.rockylinux.org/pub/rocky/9/live/x86_64/Rocky-9-MATE-x86_64-latest.iso",
               "cinnamon": "https://dl.rockylinux.org/pub/rocky/9/live/x86_64/Rocky-9-Cinnamon-x86_64-latest.iso"
+            },
+            "wslImages": {
+              "download": "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-WSL-Base.latest.x86_64.wsl"
             }
           },
           "links": {
@@ -87,6 +90,10 @@
             },
             "liveImages": {
               "checksums": "https://dl.rockylinux.org/pub/rocky/9/live/x86_64/"
+            },
+            "wslImages": {
+              "checksum": "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-WSL-Base.latest.x86_64.wsl.CHECKSUM",
+              "readMe": "https://docs.rockylinux.org/guides/interoperability/import_rocky_to_wsl/"
             }
           }
         },
@@ -159,6 +166,9 @@
             },
             "rpiImages": {
               "download": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-SBC-RaspberryPi.latest.aarch64.raw.xz"
+            },
+            "wslImages": {
+              "download": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-WSL-Base.latest.aarch64.wsl"
             }
           },
           "links": {
@@ -177,6 +187,10 @@
             "rpiImages": {
               "checksum": "https://dl.rockylinux.org/pub/sig/10/altarch/aarch64/images/RockyLinuxRpi_10-latest.img.xz.sha256sum",
               "readMe": "https://dl.rockylinux.org/pub/sig/10/altarch/aarch64/images/README.txt"
+            },
+            "wslImages": {
+              "checksum": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-WSL-Base.latest.aarch64.wsl.CHECKSUM",
+              "readMe": "https://docs.rockylinux.org/guides/interoperability/import_rocky_to_wsl/"
             }
           }
         },
@@ -208,6 +222,9 @@
             },
             "rpiImages": {
               "download": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/RockyLinuxRpi_9-latest.img.xz"
+            },
+            "wslImages": {
+              "download": "https://dl.rockylinux.org/pub/rocky/9/images/aarch64/Rocky-9-WSL-Base.latest.aarch64.wsl"
             }
           },
           "links": {
@@ -226,6 +243,10 @@
             "rpiImages": {
               "checksum": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/RockyLinuxRpi_9-latest.img.xz.sha256sum",
               "readMe": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/README.txt"
+            },
+            "wslImages": {
+              "checksum": "https://dl.rockylinux.org/pub/rocky/9/images/aarch64/Rocky-9-WSL-Base.latest.aarch64.wsl.CHECKSUM",
+              "readMe": "https://docs.rockylinux.org/guides/interoperability/import_rocky_to_wsl/"
             }
           }
         },

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -256,8 +256,8 @@
       },
       "wslImages": {
         "title": "Windows Subsystem for Linux (WSL) Images",
-        "download": "Download",
-        "readMe": "README"
+        "download": "Herunterladen",
+        "readMe": "LIESMICH"
       }
     },
     "getInvolved": {

--- a/messages/el-GR.json
+++ b/messages/el-GR.json
@@ -256,7 +256,7 @@
       },
       "wslImages": {
         "title": "Windows Subsystem for Linux (WSL) Images",
-        "download": "Download",
+        "download": "Λήψη",
         "readMe": "README"
       }
     },

--- a/messages/ka-GE.json
+++ b/messages/ka-GE.json
@@ -256,8 +256,8 @@
       },
       "wslImages": {
         "title": "Windows Subsystem for Linux (WSL) Images",
-        "download": "Download",
-        "readMe": "README"
+        "download": "გადმოწერა",
+        "readMe": "წამიკითხე"
       }
     },
     "getInvolved": {

--- a/messages/ko-KR.json
+++ b/messages/ko-KR.json
@@ -256,7 +256,7 @@
       },
       "wslImages": {
         "title": "Windows Subsystem for Linux (WSL) Images",
-        "download": "Download",
+        "download": "다운로드",
         "readMe": "README"
       }
     },

--- a/messages/pl-PL.json
+++ b/messages/pl-PL.json
@@ -256,7 +256,7 @@
       },
       "wslImages": {
         "title": "Windows Subsystem for Linux (WSL) Images",
-        "download": "Download",
+        "download": "Pobierz",
         "readMe": "README"
       }
     },

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -257,7 +257,7 @@
       "wslImages": {
         "title": "Windows Subsystem for Linux (WSL) Images",
         "download": "Download",
-        "readMe": "README"
+        "readMe": "LEIA-ME"
       }
     },
     "getInvolved": {

--- a/messages/pt-PT.json
+++ b/messages/pt-PT.json
@@ -256,8 +256,8 @@
       },
       "wslImages": {
         "title": "Windows Subsystem for Linux (WSL) Images",
-        "download": "Download",
-        "readMe": "README"
+        "download": "Descarregar",
+        "readMe": "LEIA-ME"
       }
     },
     "getInvolved": {

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -256,8 +256,8 @@
       },
       "wslImages": {
         "title": "Windows Subsystem for Linux (WSL) Images",
-        "download": "Download",
-        "readMe": "README"
+        "download": "下载",
+        "readMe": "自述文件"
       }
     },
     "getInvolved": {

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -256,7 +256,7 @@
       },
       "wslImages": {
         "title": "Windows Subsystem for Linux (WSL) Images",
-        "download": "Download",
+        "download": "下載",
         "readMe": "README"
       }
     },


### PR DESCRIPTION
This pull request introduces support for Windows Subsystem for Linux (WSL) images in the Rocky Linux download page. It includes updates to the `downloads.json` file to add WSL image links and checksums for multiple architectures and versions, modifies the `download/page.tsx` component to display WSL images for both `x86_64` and `aarch64` architectures, and updates translations for WSL-related strings in multiple languages.

### Support for WSL Images:

* [`data/downloads.json`](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R76-R78): Added entries for WSL image download links, checksums, and README URLs for Rocky Linux versions 9 and 10 on both `x86_64` and `aarch64` architectures. [[1]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R76-R78) [[2]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R93-R96) [[3]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R169-R171) [[4]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R190-R193) [[5]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R225-R227) [[6]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R246-R249)

### UI Updates:

* `app/[locale]/download/page.tsx`: Updated the conditional rendering logic to display WSL images for both `x86_64` and `aarch64` architectures. ([app/[locale]/download/page.tsxL271-R271](diffhunk://#diff-0147ff569755f73a418a60fe152d6428b369352aad4d74c4f026146204c9a7c5L271-R271))

### Translation Updates:

* Various `messages/*.json` files: Updated translations for WSL-related strings (`download`, `readMe`) in multiple languages, including German [[1]](diffhunk://#diff-0deec483567226d370cdcd4a7ff2f9302202259af8c2e62c0998096d7b05be23L259-R260) Greek [[2]](diffhunk://#diff-8b75a273b795c4c5a406039c3aa3cf84c5356136b220ef8fd586ac230d713c5bL259-R259) Georgian [[3]](diffhunk://#diff-0e00714eea75d89e9cd9d4b18cf868be7be2f9fd4a414a92220c8733d668436eL259-R260) Korean [[4]](diffhunk://#diff-5bcacd9a7ed80681d5cd90a808c7aac78a8cafc02a1ae3c2497a6849c1f762daL259-R259) Polish [[5]](diffhunk://#diff-e1536ee33424fb02b1cd2f88de61efe23f16489f73b8e600f403575bebe155b1L259-R259) Brazilian Portuguese [[6]](diffhunk://#diff-e887e5d368eefa98dcb0168d07442450590d3f739fa70893cf5cf95643dad6ddL260-R260) European Portuguese [[7]](diffhunk://#diff-d1760ee494a4d48c936f8859d0ec23f5e7e30ac8f98b2617aaae56030a9b2890L259-R260) Simplified Chinese [[8]](diffhunk://#diff-c2429cd665b3b045173d7ffc27d5f60660c9b48ffd21492ed85d699f9c68db9fL259-R260) and Traditional Chinese [[9]](diffhunk://#diff-e88103617c1a64bb7ba15f46e6241fc94aa834972625c99f947b3b6c5169a0ddL259-R259).