### PR TITLE
fix: update broken CHECKSUM link for Rocky Linux 8 images (Fixes #179)

### DIFF
--- a/data/downloads.json
+++ b/data/downloads.json
@@ -130,7 +130,7 @@
               "archived": "https://dl.rockylinux.org/vault/rocky"
             },
             "cloudImages": {
-              "checksum": "https://dl.rockylinux.org/pub/rocky/8/images/CHECKSUM"
+              "checksum": "https://dl.rockylinux.org/pub/rocky/8/images/x86_64/CHECKSUM"
             },
             "liveImages": {
               "checksums": "https://dl.rockylinux.org/pub/rocky/8/live/x86_64/"
@@ -280,7 +280,7 @@
               "archived": "https://dl.rockylinux.org/vault/rocky"
             },
             "cloudImages": {
-              "checksum": "https://dl.rockylinux.org/pub/rocky/8/images/CHECKSUM"
+              "checksum": "https://dl.rockylinux.org/pub/rocky/8.10/images/aarch64/CHECKSUM"
             },
             "rpiImages": {
               "checksum": "https://dl.rockylinux.org/pub/sig/8/altarch/aarch64/images/RockyLinuxRpi_8-latest.img.xz.sha256sum",


### PR DESCRIPTION
This PR fixes the broken CHECKSUM link on the Rocky Linux 8 images page.

Issue: [#179](https://github.com/rocky-linux/rockylinux.org/issues/179)

### Changes Made
- Updated the link to the correct path for the CHECKSUM file.
- Ensured the link is accessible and does not return 404.

Let me know if any further changes are required. Thank you!