### PR TITLE
Add missing RPI download links

### DIFF
--- a/app/[locale]/download/page.tsx
+++ b/app/[locale]/download/page.tsx
@@ -122,7 +122,9 @@ const DownloadPage = () => {
   const mapVersionToRpiVersionItem = (version: Version): VersionItem => ({
     versionName: version.versionName,
     versionId: version.versionId,
-    currentVersion: version.currentVersion,
+    currentVersion:
+      version.downloadOptions.rpiImages?.currentVersion ||
+      version.currentVersion,
     plannedEol: version.plannedEol,
     downloadOptions: version.downloadOptions.rpiImages
       ? [
@@ -149,7 +151,9 @@ const DownloadPage = () => {
   const mapVersionToWslVersionItem = (version: Version): VersionItem => ({
     versionName: version.versionName,
     versionId: version.versionId,
-    currentVersion: version.currentVersion,
+    currentVersion:
+      version.downloadOptions.wslImages?.currentVersion ||
+      version.currentVersion,
     plannedEol: version.plannedEol,
     downloadOptions: version.downloadOptions.wslImages
       ? [
@@ -178,7 +182,9 @@ const DownloadPage = () => {
   ): VersionItem => ({
     versionName: version.versionName,
     versionId: version.versionId,
-    currentVersion: version.currentVersion,
+    currentVersion:
+      version.downloadOptions.visionfive2Images?.currentVersion ||
+      version.currentVersion,
     plannedEol: version.plannedEol,
     downloadOptions: version.downloadOptions.visionfive2Images
       ? [

--- a/data/downloads.json
+++ b/data/downloads.json
@@ -165,6 +165,7 @@
               "kde": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-KDE-aarch64-latest.iso"
             },
             "rpiImages": {
+              "currentVersion": "v10.0",
               "download": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-SBC-RaspberryPi.latest.aarch64.raw.xz"
             },
             "specializedDevices": [
@@ -229,6 +230,7 @@
               "cinnamon": "https://dl.rockylinux.org/pub/rocky/9/live/aarch64/Rocky-9-Cinnamon-aarch64-latest.iso"
             },
             "rpiImages": {
+              "currentVersion": "v9.2",
               "download": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/RockyRpi_9.2.img.xz"
             },
             "specializedDevices": [
@@ -281,6 +283,7 @@
               "qcow2": "https://dl.rockylinux.org/pub/rocky/8/images/aarch64/Rocky-8-GenericCloud-Base.latest.aarch64.qcow2"
             },
             "rpiImages": {
+              "currentVersion": "v8.8",
               "download": "https://dl.rockylinux.org/pub/sig/8/altarch/aarch64/images/RockyRpi_8.8.img.xz"
             },
             "container": {

--- a/data/downloads.json
+++ b/data/downloads.json
@@ -164,6 +164,9 @@
               "gnomeLite": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-Workstation-Lite-aarch64-latest.iso",
               "kde": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-KDE-aarch64-latest.iso"
             },
+            "rpiImages": {
+              "download": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-SBC-RaspberryPi.latest.aarch64.raw.xz"
+            },
             "specializedDevices": [
               {
                 "name": "Raspberry Pi",
@@ -188,6 +191,10 @@
             },
             "liveImages": {
               "checksums": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/"
+            },
+            "rpiImages": {
+              "checksum": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-SBC-RaspberryPi.latest.aarch64.raw.xz.CHECKSUM",
+              "readMe": "https://dl.rockylinux.org/pub/sig/10/altarch/aarch64/images/README.txt"
             },
             "wslImages": {
               "checksum": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-WSL-Base.latest.aarch64.wsl.CHECKSUM",
@@ -221,6 +228,9 @@
               "mate": "https://dl.rockylinux.org/pub/rocky/9/live/aarch64/Rocky-9-MATE-aarch64-latest.iso",
               "cinnamon": "https://dl.rockylinux.org/pub/rocky/9/live/aarch64/Rocky-9-Cinnamon-aarch64-latest.iso"
             },
+            "rpiImages": {
+              "download": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/RockyRpi_9.2.img.xz"
+            },
             "specializedDevices": [
               {
                 "name": "Raspberry Pi",
@@ -242,6 +252,10 @@
             },
             "cloudImages": {
               "checksum": "https://dl.rockylinux.org/pub/rocky/9/images/aarch64/CHECKSUM"
+            },
+            "rpiImages": {
+              "checksum": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/RockyRpi_9.2.img.xz.sha256sum",
+              "readMe": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/README.txt"
             },
             "liveImages": {
               "checksums": "https://dl.rockylinux.org/pub/rocky/9/live/aarch64/"
@@ -266,6 +280,9 @@
             "cloudImages": {
               "qcow2": "https://dl.rockylinux.org/pub/rocky/8/images/aarch64/Rocky-8-GenericCloud-Base.latest.aarch64.qcow2"
             },
+            "rpiImages": {
+              "download": "https://dl.rockylinux.org/pub/sig/8/altarch/aarch64/images/RockyRpi_8.8.img.xz"
+            },
             "container": {
               "fullImage": "https://hub.docker.com/layers/library/rockylinux/8/images/sha256-be879ad24fd5387ed135b99ebf0622c323afab20ff7f1967d6f06e5dbf07ee31?context=explore",
               "minimalImage": "https://hub.docker.com/layers/library/rockylinux/8-minimal/images/sha256-46c797fad395827bf7d861a3c1c5b87c4e737ea1b6df13da58ee7a3478065bc5?context=explore"
@@ -282,7 +299,7 @@
               "checksum": "https://dl.rockylinux.org/pub/rocky/8.10/images/aarch64/CHECKSUM"
             },
             "rpiImages": {
-              "checksum": "https://dl.rockylinux.org/pub/sig/8/altarch/aarch64/images/RockyLinuxRpi_8-latest.img.xz.sha256sum",
+              "checksum": "https://dl.rockylinux.org/pub/sig/8/altarch/aarch64/images/RockyRpi_8.8.img.xz.sha256sum",
               "readMe": "https://dl.rockylinux.org/pub/sig/8/altarch/aarch64/images/README.txt"
             }
           }

--- a/types/downloads.ts
+++ b/types/downloads.ts
@@ -46,12 +46,15 @@ export interface DownloadOptions {
     cinnamon?: string;
   };
   rpiImages?: {
+    currentVersion?: string;
     download: string;
   };
   wslImages?: {
+    currentVersion?: string;
     download: string;
   };
   visionfive2Images?: {
+    currentVersion?: string;
     download: string;
   };
   specializedDevices?: SpecializedDevice[];
@@ -71,14 +74,17 @@ export interface Links {
     checksums: string;
   };
   rpiImages?: {
+    currentVersion?: string;
     checksum: string;
     readMe: string;
   };
   wslImages?: {
+    currentVersion?: string;
     checksum: string;
     readMe: string;
   };
   visionfive2Images?: {
+    currentVersion?: string;
     checksum: string;
     readMe?: string;
   };


### PR DESCRIPTION
This pull request enhances the download page by adding missing Raspberry Pi versions (`rpiImages`) and improves the handling of version-specific download options. The most important changes include updates to the data structure, adjustments to the mapping logic, and modifications to the type definitions.

### Enhancements to download page logic:

* Updated the `currentVersion` mapping logic in `app/[locale]/download/page.tsx` to prioritize `currentVersion` from `rpiImages`, `wslImages`, and `visionfive2Images` over the general `currentVersion` field. ([app/[locale]/download/page.tsxL125-R127](diffhunk://#diff-0147ff569755f73a418a60fe152d6428b369352aad4d74c4f026146204c9a7c5L125-R127), [app/[locale]/download/page.tsxL152-R156](diffhunk://#diff-0147ff569755f73a418a60fe152d6428b369352aad4d74c4f026146204c9a7c5L152-R156), [app/[locale]/download/page.tsxL181-R187](diffhunk://#diff-0147ff569755f73a418a60fe152d6428b369352aad4d74c4f026146204c9a7c5L181-R187))

### Updates to data structure:

* Added `rpiImages` entries for versions 10, 9, and 8 in `data/downloads.json`, including `currentVersion`, `download`, `checksum`, and `readMe` fields. Updated the checksum for version 8.8. [[1]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R167-R170) [[2]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R196-R199) [[3]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R232-R235) [[4]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R258-R261) [[5]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R285-R288) [[6]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9L285-R305)

### Modifications to type definitions:

* Extended the `DownloadOptions` and `Links` interfaces in `types/downloads.ts` to include an optional `currentVersion` field for `rpiImages`, `wslImages`, and `visionfive2Images`. [[1]](diffhunk://#diff-9b4e10b44a1565c659edd6ed75b681f03e8c624493101a43808861ed795d2368R49-R57) [[2]](diffhunk://#diff-9b4e10b44a1565c659edd6ed75b681f03e8c624493101a43808861ed795d2368R77-R87)