### PR TITLE
Add missing RPI download links and updates

### DIFF
--- a/app/[locale]/download/page.tsx
+++ b/app/[locale]/download/page.tsx
@@ -122,7 +122,9 @@ const DownloadPage = () => {
   const mapVersionToRpiVersionItem = (version: Version): VersionItem => ({
     versionName: version.versionName,
     versionId: version.versionId,
-    currentVersion: version.currentVersion,
+    currentVersion:
+      version.downloadOptions.rpiImages?.currentVersion ||
+      version.currentVersion,
     plannedEol: version.plannedEol,
     downloadOptions: version.downloadOptions.rpiImages
       ? [
@@ -149,7 +151,9 @@ const DownloadPage = () => {
   const mapVersionToWslVersionItem = (version: Version): VersionItem => ({
     versionName: version.versionName,
     versionId: version.versionId,
-    currentVersion: version.currentVersion,
+    currentVersion:
+      version.downloadOptions.wslImages?.currentVersion ||
+      version.currentVersion,
     plannedEol: version.plannedEol,
     downloadOptions: version.downloadOptions.wslImages
       ? [
@@ -178,7 +182,9 @@ const DownloadPage = () => {
   ): VersionItem => ({
     versionName: version.versionName,
     versionId: version.versionId,
-    currentVersion: version.currentVersion,
+    currentVersion:
+      version.downloadOptions.visionfive2Images?.currentVersion ||
+      version.currentVersion,
     plannedEol: version.plannedEol,
     downloadOptions: version.downloadOptions.visionfive2Images
       ? [

--- a/data/downloads.json
+++ b/data/downloads.json
@@ -165,6 +165,7 @@
               "kde": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-KDE-aarch64-latest.iso"
             },
             "rpiImages": {
+              "currentVersion": "v10.0",
               "download": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-SBC-RaspberryPi.latest.aarch64.raw.xz"
             },
             "specializedDevices": [
@@ -229,6 +230,7 @@
               "cinnamon": "https://dl.rockylinux.org/pub/rocky/9/live/aarch64/Rocky-9-Cinnamon-aarch64-latest.iso"
             },
             "rpiImages": {
+              "currentVersion": "v9.2",
               "download": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/RockyRpi_9.2.img.xz"
             },
             "specializedDevices": [
@@ -281,6 +283,7 @@
               "qcow2": "https://dl.rockylinux.org/pub/rocky/8/images/aarch64/Rocky-8-GenericCloud-Base.latest.aarch64.qcow2"
             },
             "rpiImages": {
+              "currentVersion": "v8.8",
               "download": "https://dl.rockylinux.org/pub/sig/8/altarch/aarch64/images/RockyRpi_8.8.img.xz"
             },
             "container": {

--- a/data/downloads.json
+++ b/data/downloads.json
@@ -164,6 +164,9 @@
               "gnomeLite": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-Workstation-Lite-aarch64-latest.iso",
               "kde": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/Rocky-10-KDE-aarch64-latest.iso"
             },
+            "rpiImages": {
+              "download": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-SBC-RaspberryPi.latest.aarch64.raw.xz"
+            },
             "specializedDevices": [
               {
                 "name": "Raspberry Pi",
@@ -188,6 +191,10 @@
             },
             "liveImages": {
               "checksums": "https://dl.rockylinux.org/pub/rocky/10/live/aarch64/"
+            },
+            "rpiImages": {
+              "checksum": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-SBC-RaspberryPi.latest.aarch64.raw.xz.CHECKSUM",
+              "readMe": "https://dl.rockylinux.org/pub/sig/10/altarch/aarch64/images/README.txt"
             },
             "wslImages": {
               "checksum": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-WSL-Base.latest.aarch64.wsl.CHECKSUM",
@@ -221,6 +228,9 @@
               "mate": "https://dl.rockylinux.org/pub/rocky/9/live/aarch64/Rocky-9-MATE-aarch64-latest.iso",
               "cinnamon": "https://dl.rockylinux.org/pub/rocky/9/live/aarch64/Rocky-9-Cinnamon-aarch64-latest.iso"
             },
+            "rpiImages": {
+              "download": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/RockyRpi_9.2.img.xz"
+            },
             "specializedDevices": [
               {
                 "name": "Raspberry Pi",
@@ -242,6 +252,10 @@
             },
             "cloudImages": {
               "checksum": "https://dl.rockylinux.org/pub/rocky/9/images/aarch64/CHECKSUM"
+            },
+            "rpiImages": {
+              "checksum": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/RockyRpi_9.2.img.xz.sha256sum",
+              "readMe": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/README.txt"
             },
             "liveImages": {
               "checksums": "https://dl.rockylinux.org/pub/rocky/9/live/aarch64/"
@@ -266,6 +280,9 @@
             "cloudImages": {
               "qcow2": "https://dl.rockylinux.org/pub/rocky/8/images/aarch64/Rocky-8-GenericCloud-Base.latest.aarch64.qcow2"
             },
+            "rpiImages": {
+              "download": "https://dl.rockylinux.org/pub/sig/8/altarch/aarch64/images/RockyRpi_8.8.img.xz"
+            },
             "container": {
               "fullImage": "https://hub.docker.com/layers/library/rockylinux/8/images/sha256-be879ad24fd5387ed135b99ebf0622c323afab20ff7f1967d6f06e5dbf07ee31?context=explore",
               "minimalImage": "https://hub.docker.com/layers/library/rockylinux/8-minimal/images/sha256-46c797fad395827bf7d861a3c1c5b87c4e737ea1b6df13da58ee7a3478065bc5?context=explore"
@@ -282,7 +299,7 @@
               "checksum": "https://dl.rockylinux.org/pub/rocky/8.10/images/aarch64/CHECKSUM"
             },
             "rpiImages": {
-              "checksum": "https://dl.rockylinux.org/pub/sig/8/altarch/aarch64/images/RockyLinuxRpi_8-latest.img.xz.sha256sum",
+              "checksum": "https://dl.rockylinux.org/pub/sig/8/altarch/aarch64/images/RockyRpi_8.8.img.xz.sha256sum",
               "readMe": "https://dl.rockylinux.org/pub/sig/8/altarch/aarch64/images/README.txt"
             }
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "js-cookie": "^3.0.5",
         "lodash": "^4.17.21",
         "lucide-react": "^0.503.0",
-        "next": "15.3.1",
+        "next": "15.3.5",
         "next-intl": "^4.3.1",
         "next-plausible": "^3.12.4",
         "next-themes": "^0.4.6",
@@ -2026,9 +2026,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.1.tgz",
-      "integrity": "sha512-cwK27QdzrMblHSn9DZRV+DQscHXRuJv6MydlJRpFSqJWZrTYMLzKDeyueJNN9MGd8NNiUKzDQADAf+dMLXX7YQ==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.5.tgz",
+      "integrity": "sha512-7g06v8BUVtN2njAX/r8gheoVffhiKFVt4nx74Tt6G4Hqw9HCLYQVx/GkH2qHvPtAHZaUNZ0VXAa0pQP6v1wk7g==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2069,9 +2069,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.1.tgz",
-      "integrity": "sha512-hjDw4f4/nla+6wysBL07z52Gs55Gttp5Bsk5/8AncQLJoisvTBP0pRIBK/B16/KqQyH+uN4Ww8KkcAqJODYH3w==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.5.tgz",
+      "integrity": "sha512-lM/8tilIsqBq+2nq9kbTW19vfwFve0NR7MxfkuSUbRSgXlMQoJYg+31+++XwKVSXk4uT23G2eF/7BRIKdn8t8w==",
       "cpu": [
         "arm64"
       ],
@@ -2085,9 +2085,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.1.tgz",
-      "integrity": "sha512-q+aw+cJ2ooVYdCEqZVk+T4Ni10jF6Fo5DfpEV51OupMaV5XL6pf3GCzrk6kSSZBsMKZtVC1Zm/xaNBFpA6bJ2g==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.5.tgz",
+      "integrity": "sha512-WhwegPQJ5IfoUNZUVsI9TRAlKpjGVK0tpJTL6KeiC4cux9774NYE9Wu/iCfIkL/5J8rPAkqZpG7n+EfiAfidXA==",
       "cpu": [
         "x64"
       ],
@@ -2101,9 +2101,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.1.tgz",
-      "integrity": "sha512-wBQ+jGUI3N0QZyWmmvRHjXjTWFy8o+zPFLSOyAyGFI94oJi+kK/LIZFJXeykvgXUk1NLDAEFDZw/NVINhdk9FQ==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.5.tgz",
+      "integrity": "sha512-LVD6uMOZ7XePg3KWYdGuzuvVboxujGjbcuP2jsPAN3MnLdLoZUXKRc6ixxfs03RH7qBdEHCZjyLP/jBdCJVRJQ==",
       "cpu": [
         "arm64"
       ],
@@ -2117,9 +2117,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.1.tgz",
-      "integrity": "sha512-IIxXEXRti/AulO9lWRHiCpUUR8AR/ZYLPALgiIg/9ENzMzLn3l0NSxVdva7R/VDcuSEBo0eGVCe3evSIHNz0Hg==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.5.tgz",
+      "integrity": "sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==",
       "cpu": [
         "arm64"
       ],
@@ -2133,9 +2133,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.1.tgz",
-      "integrity": "sha512-bfI4AMhySJbyXQIKH5rmLJ5/BP7bPwuxauTvVEiJ/ADoddaA9fgyNNCcsbu9SlqfHDoZmfI6g2EjzLwbsVTr5A==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.5.tgz",
+      "integrity": "sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==",
       "cpu": [
         "x64"
       ],
@@ -2149,9 +2149,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.1.tgz",
-      "integrity": "sha512-FeAbR7FYMWR+Z+M5iSGytVryKHiAsc0x3Nc3J+FD5NVbD5Mqz7fTSy8CYliXinn7T26nDMbpExRUI/4ekTvoiA==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.5.tgz",
+      "integrity": "sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==",
       "cpu": [
         "x64"
       ],
@@ -2165,9 +2165,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.1.tgz",
-      "integrity": "sha512-yP7FueWjphQEPpJQ2oKmshk/ppOt+0/bB8JC8svPUZNy0Pi3KbPx2Llkzv1p8CoQa+D2wknINlJpHf3vtChVBw==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.5.tgz",
+      "integrity": "sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==",
       "cpu": [
         "arm64"
       ],
@@ -2181,9 +2181,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.1.tgz",
-      "integrity": "sha512-3PMvF2zRJAifcRNni9uMk/gulWfWS+qVI/pagd+4yLF5bcXPZPPH2xlYRYOsUjmCJOXSTAC2PjRzbhsRzR2fDQ==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.5.tgz",
+      "integrity": "sha512-5fhH6fccXxnX2KhllnGhkYMndhOiLOLEiVGYjP2nizqeGWkN10sA9taATlXwake2E2XMvYZjjz0Uj7T0y+z1yw==",
       "cpu": [
         "x64"
       ],
@@ -11596,12 +11596,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.3.1.tgz",
-      "integrity": "sha512-8+dDV0xNLOgHlyBxP1GwHGVaNXsmp+2NhZEYrXr24GWLHtt27YrBPbPuHvzlhi7kZNYjeJNR93IF5zfFu5UL0g==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.3.5.tgz",
+      "integrity": "sha512-RkazLBMMDJSJ4XZQ81kolSpwiCt907l0xcgcpF4xC2Vml6QVcPNXW0NQRwQ80FFtSn7UM52XN0anaw8TEJXaiw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.3.1",
+        "@next/env": "15.3.5",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -11616,14 +11616,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.3.1",
-        "@next/swc-darwin-x64": "15.3.1",
-        "@next/swc-linux-arm64-gnu": "15.3.1",
-        "@next/swc-linux-arm64-musl": "15.3.1",
-        "@next/swc-linux-x64-gnu": "15.3.1",
-        "@next/swc-linux-x64-musl": "15.3.1",
-        "@next/swc-win32-arm64-msvc": "15.3.1",
-        "@next/swc-win32-x64-msvc": "15.3.1",
+        "@next/swc-darwin-arm64": "15.3.5",
+        "@next/swc-darwin-x64": "15.3.5",
+        "@next/swc-linux-arm64-gnu": "15.3.5",
+        "@next/swc-linux-arm64-musl": "15.3.5",
+        "@next/swc-linux-x64-gnu": "15.3.5",
+        "@next/swc-linux-x64-musl": "15.3.5",
+        "@next/swc-win32-arm64-msvc": "15.3.5",
+        "@next/swc-win32-x64-msvc": "15.3.5",
         "sharp": "^0.34.1"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "js-cookie": "^3.0.5",
     "lodash": "^4.17.21",
     "lucide-react": "^0.503.0",
-    "next": "15.3.1",
+    "next": "15.3.5",
     "next-intl": "^4.3.1",
     "next-plausible": "^3.12.4",
     "next-themes": "^0.4.6",

--- a/types/downloads.ts
+++ b/types/downloads.ts
@@ -46,12 +46,15 @@ export interface DownloadOptions {
     cinnamon?: string;
   };
   rpiImages?: {
+    currentVersion?: string;
     download: string;
   };
   wslImages?: {
+    currentVersion?: string;
     download: string;
   };
   visionfive2Images?: {
+    currentVersion?: string;
     download: string;
   };
   specializedDevices?: SpecializedDevice[];
@@ -71,14 +74,17 @@ export interface Links {
     checksums: string;
   };
   rpiImages?: {
+    currentVersion?: string;
     checksum: string;
     readMe: string;
   };
   wslImages?: {
+    currentVersion?: string;
     checksum: string;
     readMe: string;
   };
   visionfive2Images?: {
+    currentVersion?: string;
     checksum: string;
     readMe?: string;
   };


### PR DESCRIPTION
This pull request introduces support for Raspberry Pi (RPI) images in the download page and updates dependencies. The key changes include adding RPI-specific data to the `downloads.json` file, updating the `DownloadPage` logic to handle RPI images, modifying the TypeScript types to include RPI-specific fields, and upgrading the `next` dependency.

### Support for Raspberry Pi images:

* `app/[locale]/download/page.tsx`: Updated the `mapVersionToRpiVersionItem`, `mapVersionToWslVersionItem`, and related functions to prioritize `currentVersion` from `rpiImages`, `wslImages`, and `visionfive2Images` when available. This ensures accurate version information for RPI and other specialized images. ([app/[locale]/download/page.tsxL125-R127](diffhunk://#diff-0147ff569755f73a418a60fe152d6428b369352aad4d74c4f026146204c9a7c5L125-R127), [app/[locale]/download/page.tsxL152-R156](diffhunk://#diff-0147ff569755f73a418a60fe152d6428b369352aad4d74c4f026146204c9a7c5L152-R156), [app/[locale]/download/page.tsxL181-R187](diffhunk://#diff-0147ff569755f73a418a60fe152d6428b369352aad4d74c4f026146204c9a7c5L181-R187))

* [`data/downloads.json`](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R167-R170): Added `rpiImages` data for Rocky Linux versions 8, 9, and 10, including fields for `currentVersion`, `download`, `checksum`, and `readMe`. This enables the download page to display RPI-specific image links and metadata. [[1]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R167-R170) [[2]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R196-R199) [[3]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R232-R235) [[4]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R258-R261) [[5]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9R285-R288) [[6]](diffhunk://#diff-aaf3ac0660fa4e2e48faac71aa7afe2816671df41544074bc7ef178dc5e397d9L285-R305)

* [`types/downloads.ts`](diffhunk://#diff-9b4e10b44a1565c659edd6ed75b681f03e8c624493101a43808861ed795d2368R49-R57): Extended the `DownloadOptions` and `Links` interfaces to include optional `currentVersion`, `download`, `checksum`, and `readMe` fields for `rpiImages`, `wslImages`, and `visionfive2Images`. This ensures type safety when working with these new fields. [[1]](diffhunk://#diff-9b4e10b44a1565c659edd6ed75b681f03e8c624493101a43808861ed795d2368R49-R57) [[2]](diffhunk://#diff-9b4e10b44a1565c659edd6ed75b681f03e8c624493101a43808861ed795d2368R77-R87)

### Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49-R49): Upgraded the `next` dependency from version `15.3.1` to `15.3.5` to incorporate the latest bug fixes and improvements.