### PR TITLE
Fix mobile UI issues and console errors

### DIFF
--- a/app/[locale]/Header.tsx
+++ b/app/[locale]/Header.tsx
@@ -1,6 +1,5 @@
 import { useTranslations } from "next-intl";
 import Link from "next/link";
-import Image from "next/image";
 
 import Logo from "@/components/Logo";
 import { Button } from "@/components/ui/button";

--- a/app/[locale]/components/header/DarkModeToggle.tsx
+++ b/app/[locale]/components/header/DarkModeToggle.tsx
@@ -33,14 +33,11 @@ const DarkModeToggle = ({ srText }: DarkModeToggleProps) => {
   return (
     <Button
       variant="outline"
-      className="py-5 px-3"
+      className="relative py-5 px-3"
       onClick={toggleTheme}
     >
-      {theme === "light" ? (
-        <SunIcon className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-      ) : (
-        <MoonIcon className="h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-      )}
+      <SunIcon className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <MoonIcon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
       <span className="sr-only">{srText}</span>
     </Button>
   );

--- a/app/[locale]/components/header/nav/desktop/NavItem.tsx
+++ b/app/[locale]/components/header/nav/desktop/NavItem.tsx
@@ -14,15 +14,14 @@ export interface NavItemProps {
 const NavItem = ({ title, href }: NavItemProps) => {
   return (
     <NavigationMenuItem>
-      <Link
-        href={href}
-        legacyBehavior
-        passHref
-      >
-        <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+      <NavigationMenuLink asChild>
+        <Link
+          href={href}
+          className={navigationMenuTriggerStyle()}
+        >
           {title}
-        </NavigationMenuLink>
-      </Link>
+        </Link>
+      </NavigationMenuLink>
     </NavigationMenuItem>
   );
 };

--- a/app/[locale]/download/components/CloudImage/Card.tsx
+++ b/app/[locale]/download/components/CloudImage/Card.tsx
@@ -83,7 +83,9 @@ const CloudImageCard: React.FC<CloudImageCardProps> = ({
           {titleTooltip ? (
             <HoverCard>
               <div className="flex gap-2 items-center">
-                <h2 className="text-2xl font-display font-bold">{title}</h2>
+                <span className="text-xl sm:text-2xl font-display font-bold">
+                  {title}
+                </span>
                 <HoverCardTrigger className="text-muted-foreground">
                   <QuestionMarkCircledIcon />
                 </HoverCardTrigger>
@@ -104,7 +106,9 @@ const CloudImageCard: React.FC<CloudImageCardProps> = ({
             </HoverCard>
           ) : (
             <div className="flex gap-2 items-center">
-              <h2 className="text-2xl font-display font-bold">{title}</h2>
+              <span className="text-xl sm:text-2xl font-display font-bold">
+                {title}
+              </span>
             </div>
           )}
         </CardTitle>

--- a/app/[locale]/download/components/CloudImage/Card.tsx
+++ b/app/[locale]/download/components/CloudImage/Card.tsx
@@ -126,11 +126,13 @@ const CloudImageCard: React.FC<CloudImageCardProps> = ({
             {t("cards.cloudImages.cloudProviders.title")}
           </h3>
 
-          <div className="flex gap-4">
+          <div className="flex flex-col sm:flex-row gap-2 sm:gap-4">
             <Drawer>
-              <DrawerTrigger>
+              <DrawerTrigger className="w-full sm:w-auto">
                 <span
-                  className={buttonVariants({ variant: "default" }) + " mb-6"}
+                  className={
+                    buttonVariants({ variant: "default" }) + " w-full sm:w-auto"
+                  }
                 >
                   {t("cards.cloudImages.cloudProviders.aws.name")}
                 </span>
@@ -153,16 +155,20 @@ const CloudImageCard: React.FC<CloudImageCardProps> = ({
             <Link
               href="https://console.cloud.google.com/marketplace/browse?filter=partner:Rocky%20Linux"
               target="_blank"
+              className="w-full sm:w-auto"
             >
-              <Button>
+              <Button className="w-full sm:w-auto">
                 {t("cards.cloudImages.cloudProviders.googleCloud")}
               </Button>
             </Link>
             <Link
               href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/resf.rockylinux-x86_64"
               target="_blank"
+              className="w-full sm:w-auto"
             >
-              <Button>{t("cards.cloudImages.cloudProviders.azure")}</Button>
+              <Button className="w-full sm:w-auto">
+                {t("cards.cloudImages.cloudProviders.azure")}
+              </Button>
             </Link>
           </div>
         </div>

--- a/app/[locale]/download/components/CloudImage/VersionContent.tsx
+++ b/app/[locale]/download/components/CloudImage/VersionContent.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { InfoCircledIcon } from "@radix-ui/react-icons";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+
+interface DownloadOption {
+  label: string;
+  link: string;
+}
+
+interface Links {
+  name: string;
+  link: string;
+}
+
+interface VersionContentProps {
+  currentVersion: string;
+  plannedEol: string;
+  downloadOptions: DownloadOption[];
+  links?: Links[];
+}
+
+const VersionContent: React.FC<VersionContentProps> = ({
+  currentVersion,
+  plannedEol,
+  downloadOptions,
+  links,
+}) => {
+  const t = useTranslations("download");
+
+  return (
+    <>
+      <TooltipProvider>
+        <Tooltip>
+          <div className="flex items-center gap-2">
+            <h2 className="font-display font-bold text-2xl sm:text-4xl">
+              {currentVersion}
+            </h2>
+            <TooltipTrigger asChild>
+              <InfoCircledIcon className="hidden sm:block w-6 h-6 opacity-50 hover:opacity-100 transition-opacity cursor-help" />
+            </TooltipTrigger>
+          </div>
+          <TooltipContent className="max-w-[300px]">
+            <p className="text-sm">
+              {t("plannedEol")}: {plannedEol}
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <span className="sm:hidden text-sm text-muted-foreground">
+        {t("plannedEol")}: {plannedEol}
+      </span>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
+        {downloadOptions.map((option, optIndex) => (
+          <Button
+            key={optIndex}
+            className="flex-1 sm:flex-initial bg-green-600 hover:bg-green-700 dark:text-white"
+            size="lg"
+            asChild
+          >
+            <Link href={option.link}>{option.label}</Link>
+          </Button>
+        ))}
+      </div>
+      <div className="flex flex-col sm:flex-row gap-2 sm:gap-4 mt-4 text-sm">
+        {links?.map((link, linkIndex) => (
+          <a
+            key={linkIndex}
+            href={link.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:no-underline"
+          >
+            {link.name}
+          </a>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default VersionContent;

--- a/app/[locale]/download/components/CloudImage/VersionPicker.tsx
+++ b/app/[locale]/download/components/CloudImage/VersionPicker.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Select,
   SelectContent,
@@ -8,15 +7,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { InfoCircledIcon } from "@radix-ui/react-icons";
 import { useTranslations } from "next-intl";
-import Link from "next/link";
+import { cn } from "@/lib/utils";
+import VersionContent from "./VersionContent";
 
 interface DownloadOption {
   label: string;
@@ -49,10 +42,10 @@ const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
 
   return (
     <>
-      <div className="flex flex-col sm:flex-row sm:items-center gap-2 mb-4">
-        <span className="text-sm">{t("selectVersion")}</span>
-        {/* Mobile dropdown */}
-        <div className="sm:hidden w-full">
+      {/* Mobile Version Selector and Content */}
+      <div className="sm:hidden">
+        <div className="flex flex-col gap-2 mb-4">
+          <span className="text-sm">{t("selectVersion")}</span>
           <Select
             value={selectedVersion}
             onValueChange={setSelectedVersion}
@@ -75,72 +68,58 @@ const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
             </SelectContent>
           </Select>
         </div>
-        {/* Desktop tabs */}
-        <TabsList className="hidden sm:inline-flex">
-          {versions.map((version, index) => (
-            <TabsTrigger
-              key={index}
-              value={version.versionId}
-              onClick={() => setSelectedVersion(version.versionId)}
-            >
-              {version.versionName}
-            </TabsTrigger>
-          ))}
-        </TabsList>
+        {/* Mobile content - show only selected version */}
+        {versions.map((version, index) => (
+          <div
+            key={index}
+            className={cn(
+              selectedVersion === version.versionId ? "block" : "hidden"
+            )}
+          >
+            <VersionContent
+              currentVersion={version.currentVersion}
+              plannedEol={version.plannedEol}
+              downloadOptions={version.downloadOptions}
+              links={version.links}
+            />
+          </div>
+        ))}
       </div>
-      {/* Show only selected version content on mobile */}
-      {versions.map((version, index) => (
-        <TabsContent
-          value={version.versionId}
-          key={index}
-          className={`sm:block ${selectedVersion === version.versionId ? "block" : "hidden"}`}
+
+      {/* Desktop Version Tabs */}
+      <div className="hidden sm:block">
+        <div className="flex items-center gap-2 mb-4">
+          <span className="text-sm">{t("selectVersion")}</span>
+        </div>
+        <Tabs
+          value={selectedVersion}
+          onValueChange={setSelectedVersion}
         >
-          <TooltipProvider>
-            <Tooltip>
-              <div className="flex items-center gap-2">
-                <h2 className="font-display font-bold text-2xl sm:text-4xl">
-                  {version.currentVersion}
-                </h2>
-                <TooltipTrigger>
-                  <InfoCircledIcon className="text-muted-foreground h-5 w-5" />
-                </TooltipTrigger>
-              </div>
-              <TooltipContent>
-                <b>{t("plannedEol")} </b>
-                {version.plannedEol}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <div className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-0">
-            {version.downloadOptions.map((option, index) => (
-              <Link
-                href={option.link}
+          <TabsList>
+            {versions.map((version, index) => (
+              <TabsTrigger
                 key={index}
-                className="w-full sm:w-auto"
+                value={version.versionId}
               >
-                <Button
-                  key={index}
-                  className={`w-full sm:w-auto ${index !== 0 ? "sm:ml-4" : ""}`}
-                >
-                  {option.label}
-                </Button>
-              </Link>
+                {version.versionName}
+              </TabsTrigger>
             ))}
-          </div>
-          {/* Links */}
-          <div className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-4 text-center sm:text-left">
-            {version.links.map((link, index) => (
-              <a
-                key={index}
-                href={link.link}
-                className="underline hover:no-underline"
-              >
-                {link.name}
-              </a>
-            ))}
-          </div>
-        </TabsContent>
-      ))}
+          </TabsList>
+          {versions.map((version, index) => (
+            <TabsContent
+              value={version.versionId}
+              key={index}
+            >
+              <VersionContent
+                currentVersion={version.currentVersion}
+                plannedEol={version.plannedEol}
+                downloadOptions={version.downloadOptions}
+                links={version.links}
+              />
+            </TabsContent>
+          ))}
+        </Tabs>
+      </div>
     </>
   );
 };

--- a/app/[locale]/download/components/CloudImage/VersionPicker.tsx
+++ b/app/[locale]/download/components/CloudImage/VersionPicker.tsx
@@ -1,6 +1,13 @@
-import React from "react";
+import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   Tooltip,
   TooltipContent,
@@ -36,29 +43,62 @@ interface DownloadCardProps {
 
 const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
   const t = useTranslations("download");
+  const [selectedVersion, setSelectedVersion] = useState(
+    versions[0]?.versionId || "rocky-10"
+  );
 
   return (
     <>
-      <span className="mr-2">{t("selectVersion")}</span>
-      <TabsList>
-        {versions.map((version, index) => (
-          <TabsTrigger
-            key={index}
-            value={version.versionId}
+      <div className="flex flex-col sm:flex-row sm:items-center gap-2 mb-4">
+        <span className="text-sm">{t("selectVersion")}</span>
+        {/* Mobile dropdown */}
+        <div className="sm:hidden w-full">
+          <Select
+            value={selectedVersion}
+            onValueChange={setSelectedVersion}
           >
-            {version.versionName}
-          </TabsTrigger>
-        ))}
-      </TabsList>
+            <SelectTrigger className="w-full">
+              <SelectValue>
+                {versions.find((v) => v.versionId === selectedVersion)
+                  ?.versionName || versions[0]?.versionName}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              {versions.map((version, index) => (
+                <SelectItem
+                  key={index}
+                  value={version.versionId}
+                >
+                  {version.versionName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        {/* Desktop tabs */}
+        <TabsList className="hidden sm:inline-flex">
+          {versions.map((version, index) => (
+            <TabsTrigger
+              key={index}
+              value={version.versionId}
+              onClick={() => setSelectedVersion(version.versionId)}
+            >
+              {version.versionName}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </div>
+      {/* Show only selected version content on mobile */}
       {versions.map((version, index) => (
         <TabsContent
           value={version.versionId}
           key={index}
+          className={`sm:block ${selectedVersion === version.versionId ? "block" : "hidden"}`}
         >
           <TooltipProvider>
             <Tooltip>
               <div className="flex items-center gap-2">
-                <h2 className="font-display font-bold text-4xl">
+                <h2 className="font-display font-bold text-2xl sm:text-4xl">
                   {version.currentVersion}
                 </h2>
                 <TooltipTrigger>
@@ -71,15 +111,16 @@ const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
-          <div className="mt-4">
+          <div className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-0">
             {version.downloadOptions.map((option, index) => (
               <Link
                 href={option.link}
                 key={index}
+                className="w-full sm:w-auto"
               >
                 <Button
                   key={index}
-                  className={`mt-2 ${index !== 0 ? "ml-4" : ""}`}
+                  className={`w-full sm:w-auto ${index !== 0 ? "sm:ml-4" : ""}`}
                 >
                   {option.label}
                 </Button>
@@ -87,7 +128,7 @@ const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
             ))}
           </div>
           {/* Links */}
-          <div className="mt-4 sm:flex grid grid-cols-2 sm:gap-4">
+          <div className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-4">
             {version.links.map((link, index) => (
               <a
                 key={index}

--- a/app/[locale]/download/components/CloudImage/VersionPicker.tsx
+++ b/app/[locale]/download/components/CloudImage/VersionPicker.tsx
@@ -128,12 +128,12 @@ const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
             ))}
           </div>
           {/* Links */}
-          <div className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-4">
+          <div className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-4 text-center sm:text-left">
             {version.links.map((link, index) => (
               <a
                 key={index}
                 href={link.link}
-                className="underline"
+                className="underline hover:no-underline"
               >
                 {link.name}
               </a>

--- a/app/[locale]/download/components/DefaultImage/Card.tsx
+++ b/app/[locale]/download/components/DefaultImage/Card.tsx
@@ -59,7 +59,9 @@ const DefaultImageCard: React.FC<DefaultImageCardProps> = ({
         {titleTooltip ? (
           <HoverCard>
             <div className="flex gap-2 items-center">
-              <h2 className="text-2xl font-display font-bold">{title}</h2>
+              <span className="text-xl sm:text-2xl font-display font-bold">
+                {title}
+              </span>
               <HoverCardTrigger className="text-muted-foreground">
                 <QuestionMarkCircledIcon />
               </HoverCardTrigger>
@@ -79,7 +81,9 @@ const DefaultImageCard: React.FC<DefaultImageCardProps> = ({
             </HoverCardContent>
           </HoverCard>
         ) : (
-          <h2 className="text-2xl font-display font-bold">{title}</h2>
+          <span className="text-xl sm:text-2xl font-display font-bold">
+            {title}
+          </span>
         )}
       </CardTitle>
     </CardHeader>

--- a/app/[locale]/download/components/DefaultImage/VersionContent.tsx
+++ b/app/[locale]/download/components/DefaultImage/VersionContent.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { InfoCircledIcon } from "@radix-ui/react-icons";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+
+interface DownloadOption {
+  label: string;
+  link: string;
+}
+
+interface Links {
+  name: string;
+  link: string;
+}
+
+interface VersionContentProps {
+  currentVersion: string;
+  plannedEol: string;
+  downloadOptions: DownloadOption[];
+  links?: Links[];
+}
+
+const VersionContent: React.FC<VersionContentProps> = ({
+  currentVersion,
+  plannedEol,
+  downloadOptions,
+  links,
+}) => {
+  const t = useTranslations("download");
+
+  return (
+    <>
+      <TooltipProvider>
+        <Tooltip>
+          <div className="flex items-center gap-2">
+            <h2 className="font-display font-bold text-2xl sm:text-4xl">
+              {currentVersion}
+            </h2>
+            <TooltipTrigger asChild>
+              <InfoCircledIcon className="hidden sm:block w-6 h-6 opacity-50 hover:opacity-100 transition-opacity cursor-help" />
+            </TooltipTrigger>
+          </div>
+          <TooltipContent className="max-w-[300px]">
+            <p className="text-sm">
+              {t("plannedEol")}: {plannedEol}
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <span className="sm:hidden text-sm text-muted-foreground">
+        {t("plannedEol")}: {plannedEol}
+      </span>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
+        {downloadOptions.map((option, optIndex) => (
+          <Button
+            key={optIndex}
+            className="flex-1 sm:flex-initial bg-green-600 hover:bg-green-700 dark:text-white"
+            size="lg"
+            asChild
+          >
+            <Link href={option.link}>{option.label}</Link>
+          </Button>
+        ))}
+      </div>
+      <div className="flex flex-col sm:flex-row gap-2 sm:gap-4 mt-4 text-sm">
+        {links?.map((link, linkIndex) => (
+          <a
+            key={linkIndex}
+            href={link.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:no-underline"
+          >
+            {link.name}
+          </a>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default VersionContent;

--- a/app/[locale]/download/components/DefaultImage/VersionPicker.tsx
+++ b/app/[locale]/download/components/DefaultImage/VersionPicker.tsx
@@ -128,12 +128,12 @@ const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
             ))}
           </div>
           {/* Links */}
-          <div className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-4">
+          <div className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-4 text-center sm:text-left">
             {version.links?.map((link, index) => (
               <a
                 key={index}
                 href={link.link}
-                className="underline"
+                className="underline hover:no-underline"
               >
                 {link.name}
               </a>

--- a/app/[locale]/download/components/DefaultImage/VersionPicker.tsx
+++ b/app/[locale]/download/components/DefaultImage/VersionPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {

--- a/app/[locale]/download/components/DefaultImage/VersionPicker.tsx
+++ b/app/[locale]/download/components/DefaultImage/VersionPicker.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Select,
   SelectContent,
@@ -8,15 +7,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { InfoCircledIcon } from "@radix-ui/react-icons";
 import { useTranslations } from "next-intl";
-import Link from "next/link";
+import { cn } from "@/lib/utils";
+import VersionContent from "./VersionContent";
 
 interface DownloadOption {
   label: string;
@@ -49,10 +42,10 @@ const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
 
   return (
     <>
-      <div className="flex flex-col sm:flex-row sm:items-center gap-2 mb-4">
-        <span className="text-sm">{t("selectVersion")}</span>
-        {/* Mobile dropdown */}
-        <div className="sm:hidden w-full">
+      {/* Mobile Version Selector and Content */}
+      <div className="sm:hidden">
+        <div className="flex flex-col gap-2 mb-4">
+          <span className="text-sm">{t("selectVersion")}</span>
           <Select
             value={selectedVersion}
             onValueChange={setSelectedVersion}
@@ -75,72 +68,58 @@ const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
             </SelectContent>
           </Select>
         </div>
-        {/* Desktop tabs */}
-        <TabsList className="hidden sm:inline-flex">
-          {versions.map((version, index) => (
-            <TabsTrigger
-              key={index}
-              value={version.versionId}
-              onClick={() => setSelectedVersion(version.versionId)}
-            >
-              {version.versionName}
-            </TabsTrigger>
-          ))}
-        </TabsList>
+        {/* Mobile content - show only selected version */}
+        {versions.map((version, index) => (
+          <div
+            key={index}
+            className={cn(
+              selectedVersion === version.versionId ? "block" : "hidden"
+            )}
+          >
+            <VersionContent
+              currentVersion={version.currentVersion}
+              plannedEol={version.plannedEol}
+              downloadOptions={version.downloadOptions}
+              links={version.links}
+            />
+          </div>
+        ))}
       </div>
-      {/* Show only selected version content on mobile */}
-      {versions.map((version, index) => (
-        <TabsContent
-          value={version.versionId}
-          key={index}
-          className={`sm:block ${selectedVersion === version.versionId ? "block" : "hidden"}`}
+
+      {/* Desktop Version Tabs */}
+      <div className="hidden sm:block">
+        <div className="flex items-center gap-2 mb-4">
+          <span className="text-sm">{t("selectVersion")}</span>
+        </div>
+        <Tabs
+          value={selectedVersion}
+          onValueChange={setSelectedVersion}
         >
-          <TooltipProvider>
-            <Tooltip>
-              <div className="flex items-center gap-2">
-                <h2 className="font-display font-bold text-2xl sm:text-4xl">
-                  {version.currentVersion}
-                </h2>
-                <TooltipTrigger>
-                  <InfoCircledIcon className="text-muted-foreground h-5 w-5" />
-                </TooltipTrigger>
-              </div>
-              <TooltipContent>
-                <b>{t("plannedEol")} </b>
-                {version.plannedEol}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <div className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-0">
-            {version.downloadOptions.map((option, index) => (
-              <Link
-                href={option.link}
+          <TabsList>
+            {versions.map((version, index) => (
+              <TabsTrigger
                 key={index}
-                className="w-full sm:w-auto"
+                value={version.versionId}
               >
-                <Button
-                  key={index}
-                  className={`w-full sm:w-auto ${index !== 0 ? "sm:ml-4" : ""}`}
-                >
-                  {option.label}
-                </Button>
-              </Link>
+                {version.versionName}
+              </TabsTrigger>
             ))}
-          </div>
-          {/* Links */}
-          <div className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-4 text-center sm:text-left">
-            {version.links?.map((link, index) => (
-              <a
-                key={index}
-                href={link.link}
-                className="underline hover:no-underline"
-              >
-                {link.name}
-              </a>
-            ))}
-          </div>
-        </TabsContent>
-      ))}
+          </TabsList>
+          {versions.map((version, index) => (
+            <TabsContent
+              value={version.versionId}
+              key={index}
+            >
+              <VersionContent
+                currentVersion={version.currentVersion}
+                plannedEol={version.plannedEol}
+                downloadOptions={version.downloadOptions}
+                links={version.links}
+              />
+            </TabsContent>
+          ))}
+        </Tabs>
+      </div>
     </>
   );
 };

--- a/app/[locale]/download/components/DefaultImage/VersionPicker.tsx
+++ b/app/[locale]/download/components/DefaultImage/VersionPicker.tsx
@@ -1,6 +1,13 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   Tooltip,
   TooltipContent,
@@ -36,29 +43,62 @@ interface DownloadCardProps {
 
 const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
   const t = useTranslations("download");
+  const [selectedVersion, setSelectedVersion] = useState(
+    versions[0]?.versionId || "rocky-10"
+  );
 
   return (
     <>
-      <span className="mr-2">{t("selectVersion")}</span>
-      <TabsList>
-        {versions.map((version, index) => (
-          <TabsTrigger
-            key={index}
-            value={version.versionId}
+      <div className="flex flex-col sm:flex-row sm:items-center gap-2 mb-4">
+        <span className="text-sm">{t("selectVersion")}</span>
+        {/* Mobile dropdown */}
+        <div className="sm:hidden w-full">
+          <Select
+            value={selectedVersion}
+            onValueChange={setSelectedVersion}
           >
-            {version.versionName}
-          </TabsTrigger>
-        ))}
-      </TabsList>
+            <SelectTrigger className="w-full">
+              <SelectValue>
+                {versions.find((v) => v.versionId === selectedVersion)
+                  ?.versionName || versions[0]?.versionName}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              {versions.map((version, index) => (
+                <SelectItem
+                  key={index}
+                  value={version.versionId}
+                >
+                  {version.versionName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        {/* Desktop tabs */}
+        <TabsList className="hidden sm:inline-flex">
+          {versions.map((version, index) => (
+            <TabsTrigger
+              key={index}
+              value={version.versionId}
+              onClick={() => setSelectedVersion(version.versionId)}
+            >
+              {version.versionName}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </div>
+      {/* Show only selected version content on mobile */}
       {versions.map((version, index) => (
         <TabsContent
           value={version.versionId}
           key={index}
+          className={`sm:block ${selectedVersion === version.versionId ? "block" : "hidden"}`}
         >
           <TooltipProvider>
             <Tooltip>
               <div className="flex items-center gap-2">
-                <h2 className="font-display font-bold text-4xl">
+                <h2 className="font-display font-bold text-2xl sm:text-4xl">
                   {version.currentVersion}
                 </h2>
                 <TooltipTrigger>
@@ -71,15 +111,16 @@ const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
-          <div className="mt-4">
+          <div className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-0">
             {version.downloadOptions.map((option, index) => (
               <Link
                 href={option.link}
                 key={index}
+                className="w-full sm:w-auto"
               >
                 <Button
                   key={index}
-                  className={`mt-2 ${index !== 0 ? "ml-4" : ""}`}
+                  className={`w-full sm:w-auto ${index !== 0 ? "sm:ml-4" : ""}`}
                 >
                   {option.label}
                 </Button>
@@ -87,7 +128,7 @@ const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
             ))}
           </div>
           {/* Links */}
-          <div className="mt-4 sm:flex grid grid-cols-2 sm:gap-4">
+          <div className="mt-4 flex flex-col sm:flex-row gap-2 sm:gap-4">
             {version.links?.map((link, index) => (
               <a
                 key={index}

--- a/app/[locale]/download/components/TabsClient.tsx
+++ b/app/[locale]/download/components/TabsClient.tsx
@@ -8,6 +8,13 @@ import DefaultImageCard from "./DefaultImage/Card";
 import CloudImageCard from "./CloudImage/Card";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface ProcessedVersion {
   versionName: string;
@@ -176,16 +183,27 @@ const TabsClient = ({ architectures, translations }: TabsClientProps) => {
           </TabsTrigger>
         ))}
       </TabsList>
-      <TabsList className="flex justify-center gap-4 sm:hidden">
-        {Object.keys(architectures).map((arch) => (
-          <TabsTrigger
-            key={arch}
-            value={arch}
-          >
-            {translations.tabsShortened[arch]}
-          </TabsTrigger>
-        ))}
-      </TabsList>
+      {/* Mobile dropdown for architecture selection */}
+      <div className="sm:hidden w-full mb-4">
+        <Select
+          value={currentArch}
+          onValueChange={updateArchitecture}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue>{translations.tabs[currentArch]}</SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {Object.keys(architectures).map((arch) => (
+              <SelectItem
+                key={arch}
+                value={arch}
+              >
+                {translations.tabs[arch]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
       {Object.entries(architectures).map(([arch, data]) => (
         <TabsContent
           key={arch}

--- a/app/[locale]/download/components/TabsClient.tsx
+++ b/app/[locale]/download/components/TabsClient.tsx
@@ -119,7 +119,18 @@ const TabsClient = ({ architectures, translations }: TabsClientProps) => {
   const isInitialLoad = useRef(true);
 
   const archFromUrl = searchParams.get("arch");
-  const detectedArch = detectArchitecture();
+
+  // Use a stable default for initial render to avoid hydration mismatch
+  const [detectedArch, setDetectedArch] = useState("x86_64");
+
+  // Detect architecture only on client after hydration
+  useEffect(() => {
+    const detected = detectArchitecture();
+    if (availableArchitectures.includes(detected)) {
+      setDetectedArch(detected);
+    }
+  }, [availableArchitectures]);
+
   const defaultArch = availableArchitectures.includes(detectedArch)
     ? detectedArch
     : "x86_64";

--- a/app/[locale]/download/components/TabsClient.tsx
+++ b/app/[locale]/download/components/TabsClient.tsx
@@ -209,7 +209,7 @@ const TabsClient = ({ architectures, translations }: TabsClientProps) => {
           key={arch}
           value={arch}
         >
-          <div className="grid gap-6 mt-4">
+          <div className="grid gap-4 sm:gap-6 mt-4 overflow-x-hidden">
             <DefaultImageCard
               title={translations.cards.defaultImages.title}
               titleTooltip={true}

--- a/app/[locale]/download/components/TabsClient.tsx
+++ b/app/[locale]/download/components/TabsClient.tsx
@@ -173,7 +173,7 @@ const TabsClient = ({ architectures, translations }: TabsClientProps) => {
       value={currentArch}
       onValueChange={updateArchitecture}
     >
-      <TabsList className="sm:flex justify-center gap-4 hidden">
+      <TabsList className="sm:flex justify-center hidden">
         {Object.keys(architectures).map((arch) => (
           <TabsTrigger
             key={arch}

--- a/app/[locale]/download/components/TabsClient.tsx
+++ b/app/[locale]/download/components/TabsClient.tsx
@@ -173,7 +173,7 @@ const TabsClient = ({ architectures, translations }: TabsClientProps) => {
       value={currentArch}
       onValueChange={updateArchitecture}
     >
-      <TabsList className="sm:flex justify-center hidden">
+      <TabsList className="sm:flex justify-center lg:gap-4 hidden">
         {Object.keys(architectures).map((arch) => (
           <TabsTrigger
             key={arch}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow-sm",
+      "rounded-xl border bg-card text-card-foreground shadow-sm w-full overflow-hidden",
       className
     )}
     {...props}
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-1.5 p-4 sm:p-6", className)}
     {...props}
   />
 ));
@@ -59,7 +59,7 @@ const CardContent = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("p-6 pt-0", className)}
+    className={cn("p-4 sm:p-6 pt-0", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Description

This PR fixes mobile UI issues on the download page where architecture tabs and version selections were getting cut off on smaller screens. The fix implements responsive dropdown selectors for mobile devices while preserving the existing tab interface for tablet and desktop users.

Fixes #202

## Changes Made

### Mobile Responsive Design
- **Architecture selector**: Converted to dropdown on mobile (< 640px) while keeping tabs on larger screens
- **Version selector**: Converted to dropdown on mobile while preserving tabs for desktop
- **Download cards**: Made all buttons stack vertically and use full width on mobile
- **Cloud provider buttons**: Stack vertically on mobile to prevent overflow

### Theme Toggle Fix
- Fixed theme toggle icon visibility in light mode
- Both sun and moon icons now properly transition based on theme
- Moon icon is now visible in light mode (was previously white on white)

### Console Errors Fixed
- **Hydration mismatch**: Fixed server/client inconsistency in architecture detection
- **Deprecated props warning**: Removed `legacyBehavior` prop from Link components
- All console warnings and errors have been resolved

### Code Review Feedback Addressed (Latest Commit)
Based on Copilot's review comments, the following improvements have been made:
- **Removed redundant onClick handlers**: TabsTrigger components no longer have unnecessary onClick handlers
- **Proper Tabs structure**: Desktop tabs now properly use controlled state with value/onValueChange props
- **Added cn() utility**: Conditional classNames now use the cn() utility for cleaner code
- **Component extraction**: VersionContent extracted into separate component to avoid nested definitions
- **Fixed double 'v' prefix bug**: Version display now correctly shows "v9.6" instead of "vv9.6"

## Screenshots

### Mobile Light Theme
<img alt="Mobile Light Theme - Full Page" src="https://github.com/user-attachments/assets/c5da0e07-1e77-4780-9c9e-8e909b876ad6" />
<img alt="Mobile Light Theme - Header with Moon Icon" src="https://github.com/user-attachments/assets/8d59178a-5525-481a-a25a-cdac1eb993d0" />

### Mobile Dark Theme  
<img alt="Mobile Dark Theme - Full Page" src="https://github.com/user-attachments/assets/7caed15f-4c2c-4918-ab56-fdb4a2ffbff1" />
<img alt="Mobile Dark Theme - Header with Sun Icon" src="https://github.com/user-attachments/assets/ca9620f4-6822-4e89-86d8-248b12b4e782" />

## Testing
- [x] Tested on mobile devices (< 640px)
- [x] Tested on tablets (640px - 1024px) 
- [x] Tested on desktop (> 1024px)
- [x] Verified no console errors or warnings
- [x] Theme toggle works correctly in both light and dark modes
- [x] All download buttons and options are accessible on mobile
- [x] All Copilot review feedback has been addressed