### PR TITLE
Fix broken download URLs in downloads.json

### DIFF
--- a/data/downloads.json
+++ b/data/downloads.json
@@ -172,7 +172,7 @@
               {
                 "name": "Raspberry Pi",
                 "download": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-SBC-RaspberryPi.latest.aarch64.raw.xz",
-                "checksum": "https://dl.rockylinux.org/pub/sig/10/altarch/aarch64/images/RockyLinuxRpi_10-latest.img.xz.sha256sum",
+                "checksum": "https://dl.rockylinux.org/pub/rocky/10/images/aarch64/Rocky-10-SBC-RaspberryPi.latest.aarch64.raw.xz.CHECKSUM",
                 "readMe": "https://dl.rockylinux.org/pub/sig/10/altarch/aarch64/images/README.txt"
               }
             ],
@@ -349,7 +349,7 @@
           "plannedEol": "May 31, 2032",
           "downloadOptions": {
             "defaultImages": {
-              "dvd": "https://download.rockylinux.org/pub/rocky/9/isos/ppc64le/Rocky-9.6-ppc64le-dvd1.iso",
+              "dvd": "https://download.rockylinux.org/pub/rocky/9/isos/ppc64le/Rocky-9.6-ppc64le-dvd.iso",
               "boot": "https://download.rockylinux.org/pub/rocky/9/isos/ppc64le/Rocky-9.6-ppc64le-boot.iso",
               "minimal": "https://download.rockylinux.org/pub/rocky/9/isos/ppc64le/Rocky-9.6-ppc64le-minimal.iso"
             },


### PR DESCRIPTION
## Summary
- Fixed broken Raspberry Pi 10 checksum URL to match the actual download file pattern
- Fixed ppc64le DVD ISO filename by removing '1' from 'dvd1'

## Details

The `check-download-urls.js` script identified 2 broken download URLs that have been corrected:

1. **Raspberry Pi 10 checksum** - Updated from the non-existent sig/10/altarch path to the correct rocky/10/images path to match the download URL pattern
2. **PPC64LE DVD ISO** - The actual file is named `Rocky-9.6-ppc64le-dvd.iso` not `Rocky-9.6-ppc64le-dvd1.iso`

Both URLs have been verified to return HTTP 200 responses.

## Test plan
- [x] Run `node scripts/check-download-urls.js` to verify the fixes
- [x] Manually tested both URLs with curl to confirm they're accessible

🤖 Generated with [Claude Code](https://claude.ai/code)