### PR TITLE
Fix Downloads

### DIFF
--- a/__tests__/next.config.test.ts
+++ b/__tests__/next.config.test.ts
@@ -10,7 +10,7 @@ jest.mock("next-intl/plugin", () => {
   });
 });
 
-import nextConfig from "../next.config";
+import nextConfig from "../next.config.mjs";
 
 describe("next.config", () => {
   describe("images", () => {

--- a/app/[locale]/download/components/CloudImage/Card.tsx
+++ b/app/[locale]/download/components/CloudImage/Card.tsx
@@ -26,6 +26,7 @@ import { Url } from "next/dist/shared/lib/router/router";
 import { CloudImage, Columns } from "./Table/Columns";
 import { DataTable } from "./Table/DataTable";
 import cloudImages from "@/data/cloud-images.json";
+import { cn } from "@/lib/utils";
 
 interface DownloadOption {
   label: string;
@@ -76,6 +77,11 @@ const CloudImageCard: React.FC<CloudImageCardProps> = ({
   const t = useTranslations("download");
   const tGlobal = useTranslations("global");
 
+  const hasCloudImages =
+    versions.length > 0 &&
+    versions[0].downloadOptions.length > 0 &&
+    versions[0].links.length > 0;
+
   return (
     <Card>
       <CardHeader>
@@ -113,15 +119,19 @@ const CloudImageCard: React.FC<CloudImageCardProps> = ({
           )}
         </CardTitle>
       </CardHeader>
-      <CardContent>
-        <h3 className="text-lg font-display font-bold">
-          {t("cards.cloudImages.genericCloud")}
-        </h3>
-        <Tabs defaultValue="rocky-10">
-          <VersionPicker versions={versions} />
-        </Tabs>
-        <hr className="my-8" />
-        <div className="mt-8">
+      <CardContent className={cn(!hasCloudImages ? "sm:!pt-0" : "")}>
+        {hasCloudImages && (
+          <>
+            <h3 className="text-lg font-display font-bold">
+              {t("cards.cloudImages.genericCloud")}
+            </h3>
+            <Tabs defaultValue="rocky-10">
+              <VersionPicker versions={versions} />
+            </Tabs>
+            <hr className="my-8" />
+          </>
+        )}
+        <div className={cn(hasCloudImages ? "mt-8" : "")}>
           <h3 className="text-lg font-display font-bold mb-4">
             {t("cards.cloudImages.cloudProviders.title")}
           </h3>

--- a/app/[locale]/download/components/CloudImage/VersionPicker.tsx
+++ b/app/[locale]/download/components/CloudImage/VersionPicker.tsx
@@ -69,21 +69,23 @@ const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
           </Select>
         </div>
         {/* Mobile content - show only selected version */}
-        {versions.map((version, index) => (
-          <div
-            key={index}
-            className={cn(
-              selectedVersion === version.versionId ? "block" : "hidden"
-            )}
-          >
-            <VersionContent
-              currentVersion={version.currentVersion}
-              plannedEol={version.plannedEol}
-              downloadOptions={version.downloadOptions}
-              links={version.links}
-            />
-          </div>
-        ))}
+        {versions
+          .filter((v) => v.downloadOptions.length > 0 && v.links.length > 0)
+          .map((version, index) => (
+            <div
+              key={index}
+              className={cn(
+                selectedVersion === version.versionId ? "block" : "hidden"
+              )}
+            >
+              <VersionContent
+                currentVersion={version.currentVersion}
+                plannedEol={version.plannedEol}
+                downloadOptions={version.downloadOptions}
+                links={version.links}
+              />
+            </div>
+          ))}
       </div>
 
       {/* Desktop Version Tabs */}
@@ -105,19 +107,21 @@ const VersionPicker: React.FC<DownloadCardProps> = ({ versions }) => {
               </TabsTrigger>
             ))}
           </TabsList>
-          {versions.map((version, index) => (
-            <TabsContent
-              value={version.versionId}
-              key={index}
-            >
-              <VersionContent
-                currentVersion={version.currentVersion}
-                plannedEol={version.plannedEol}
-                downloadOptions={version.downloadOptions}
-                links={version.links}
-              />
-            </TabsContent>
-          ))}
+          {versions
+            .filter((v) => v.downloadOptions.length > 0 && v.links.length > 0)
+            .map((version, index) => (
+              <TabsContent
+                value={version.versionId}
+                key={index}
+              >
+                <VersionContent
+                  currentVersion={version.currentVersion}
+                  plannedEol={version.plannedEol}
+                  downloadOptions={version.downloadOptions}
+                  links={version.links}
+                />
+              </TabsContent>
+            ))}
         </Tabs>
       </div>
     </>

--- a/app/[locale]/download/components/Tabs.tsx
+++ b/app/[locale]/download/components/Tabs.tsx
@@ -137,18 +137,25 @@ const DownloadTabs = ({ downloadData }: DownloadTabsProps) => {
           };
 
           const cloudImages = {
-            downloadOptions: [
-              {
-                label: translations.cards.cloudImages.downloadOptions.qcow2,
-                link: version.downloadOptions.cloudImages.qcow2,
-              },
-            ],
-            links: [
-              {
-                name: translations.cards.defaultImages.checksum,
-                link: version.links.cloudImages.checksum,
-              },
-            ],
+            downloadOptions:
+              version.downloadOptions.cloudImages && version.links.cloudImages
+                ? [
+                    {
+                      label:
+                        translations.cards.cloudImages.downloadOptions.qcow2,
+                      link: version.downloadOptions.cloudImages.qcow2,
+                    },
+                  ]
+                : [],
+            links:
+              version.downloadOptions.cloudImages && version.links.cloudImages
+                ? [
+                    {
+                      name: translations.cards.defaultImages.checksum,
+                      link: version.links.cloudImages.checksum,
+                    },
+                  ]
+                : [],
           };
 
           const containerImages = {

--- a/data/downloads.json
+++ b/data/downloads.json
@@ -453,9 +453,6 @@
               "dvd": "https://download.rockylinux.org/pub/rocky/10/isos/riscv64/Rocky-10.0-riscv64-dvd1.iso",
               "boot": "https://download.rockylinux.org/pub/rocky/10/isos/riscv64/Rocky-10.0-riscv64-boot.iso"
             },
-            "cloudImages": {
-              "qcow2": "https://dl.rockylinux.org/pub/rocky/10/images/riscv64/Rocky-10-GenericCloud-Base.latest.riscv64.qcow2"
-            },
             "container": {
               "fullImage": "https://hub.docker.com/r/rockylinux/rockylinux/tags?name=10.0",
               "minimalImage": "https://hub.docker.com/r/rockylinux/rockylinux/tags?name=10.0-minimal"

--- a/lib/__tests__/news.test.ts
+++ b/lib/__tests__/news.test.ts
@@ -34,9 +34,7 @@ describe("News Library", () => {
       return index >= 0 ? Promise.resolve() : Promise.reject();
     });
 
-    jest
-      .spyOn(fs.promises, "readdir")
-      .mockResolvedValue(mockFileNames as unknown as Dirent[]);
+    jest.spyOn(fs.promises, "readdir").mockResolvedValue(mockFileNames as any);
 
     jest.spyOn(fs.promises, "readFile").mockImplementation((filePath) => {
       const index = mockFileNames.indexOf(path.basename(filePath.toString()));

--- a/types/downloads.ts
+++ b/types/downloads.ts
@@ -30,7 +30,7 @@ export interface DownloadOptions {
     boot: string;
     minimal?: string;
   };
-  cloudImages: {
+  cloudImages?: {
     qcow2: string;
   };
   container: {
@@ -67,7 +67,7 @@ export interface Links {
     baseOs: string;
     archived: string;
   };
-  cloudImages: {
+  cloudImages?: {
     checksum: string;
   };
   liveImages?: {


### PR DESCRIPTION
This pull request refines how cloud image download options and links are handled throughout the app, ensuring better robustness and correctness when cloud image data is missing. It introduces conditional checks so that cloud image UI elements are only rendered when relevant data is available, and updates TypeScript types to accurately reflect the optional nature of cloud image data. Additionally, it cleans up test mocks and updates imports for consistency.

**Cloud image data handling improvements:**

* Updated the construction of `cloudImages` in `Tabs.tsx` to conditionally include download options and links only when both are present, preventing rendering of empty or incomplete UI sections. ([app/[locale]/download/components/Tabs.tsxL140-R158](diffhunk://#diff-cf8f9e9c30c8584de125ca85c7d84d6f6686e55a352a1e1d936a962d1703dc9fL140-R158))
* Changed the logic in `Card.tsx` to only render cloud image sections if the `versions` array contains entries with both download options and links, and adjusted layout classes accordingly. ([app/[locale]/download/components/CloudImage/Card.tsxR80-R84](diffhunk://#diff-22d723311fecb20786074759064b47ed14bad43a3d86d6a453352f76007e5e72R80-R84), [app/[locale]/download/components/CloudImage/Card.tsxL116-R134](diffhunk://#diff-22d723311fecb20786074759064b47ed14bad43a3d86d6a453352f76007e5e72L116-R134))
* Modified filtering in `VersionPicker.tsx` so that only versions with valid cloud image download options and links are shown in both mobile and tabbed views. ([app/[locale]/download/components/CloudImage/VersionPicker.tsxL72-R74](diffhunk://#diff-44ee58ee21e3246ff73a3bdf30e2c51b51009ce55f570413386a85436768efa7L72-R74), [app/[locale]/download/components/CloudImage/VersionPicker.tsxL108-R112](diffhunk://#diff-44ee58ee21e3246ff73a3bdf30e2c51b51009ce55f570413386a85436768efa7L108-R112))

**TypeScript type updates:**

* Updated the `DownloadOptions` and `Links` interfaces in `downloads.ts` to make the `cloudImages` property optional, reflecting that some versions may not have cloud images available. [[1]](diffhunk://#diff-9b4e10b44a1565c659edd6ed75b681f03e8c624493101a43808861ed795d2368L33-R33) [[2]](diffhunk://#diff-9b4e10b44a1565c659edd6ed75b681f03e8c624493101a43808861ed795d2368L70-R70)

**Test and import maintenance:**

* Updated import in `next.config.test.ts` to use `next.config.mjs` for consistency with the codebase.
* Simplified the mock for `fs.promises.readdir` in `news.test.ts` for better type compatibility.
* Removed `cloudImages` data from the RISC-V64 entry in `downloads.json` to align with the new conditional rendering logic.