### PR TITLE
Don't allow indexing on staging domain

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,25 @@ const nextConfig = {
       },
     ],
   },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        has: [
+          {
+            type: "host",
+            value: "staging.rockylinux.org",
+          },
+        ],
+        headers: [
+          {
+            key: "X-Robots-Tag",
+            value: "noindex",
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
This pull request adds a new custom header configuration to the Next.js application. The main change is the introduction of logic that sets the `X-Robots-Tag: noindex` header for requests coming to the staging environment, which helps prevent search engines from indexing staging URLs.

Header management for staging environment:

* Added an `async headers()` function to `next.config.mjs` to set the `X-Robots-Tag: noindex` header for all requests where the host is `staging.rockylinux.org`, preventing these pages from being indexed by search engines.