### PR TITLE
Translation file update and Don't allow indexing on staging domain

### DIFF
--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -258,6 +258,16 @@
         "title": "Windows Subsystem for Linux (WSL) Images",
         "download": "Download",
         "readMe": "README"
+      },
+      "visionfive2Images": {
+        "title": "VisionFive 2 Images",
+        "download": "Download",
+        "readMe": "README"
+      },
+      "specializedDevices": {
+        "title": "Specialized Devices",
+        "download": "Download",
+        "readMe": "README"
       }
     },
     "getInvolved": {
@@ -267,7 +277,7 @@
     "exportCompliance": {
       "title": "Export Compliance/Customs Information",
       "text1": "By downloading Rocky Linux software, you acknowledge that you understand all of the following:",
-      "text2": "Rocky Linux software and technical information may be subject to the U.S. Export Administration Regulations (the “EAR”) and other U.S. and foreign laws and may not be exported, re-exported or transferred (a) to a prohibited destination country under the EAR or U.S. sanctions regulations (currently Cuba, Iran, North Korea, Sudan, Syria, and the Crimea Region of Ukraine, subject to change as posted by the United States government); (b) to any prohibited destination or to any end user who has been prohibited from participating in U.S. export transactions by any federal agency of the U.S. government; or (c) for use in connection with the design, development or production of nuclear, chemical or biological weapons, or rocket systems, space launch vehicles, or sounding rockets, or unmanned air vehicle systems.",
+      "text2": "Rocky Linux software and technical information may be subject to the U.S. Export Administration Regulations (the \"EAR\") and other U.S. and foreign laws and may not be exported, re-exported or transferred (a) to a prohibited destination country under the EAR or U.S. sanctions regulations (currently Cuba, Iran, North Korea, Sudan, Syria, and the Crimea Region of Ukraine, subject to change as posted by the United States government); (b) to any prohibited destination or to any end user who has been prohibited from participating in U.S. export transactions by any federal agency of the U.S. government; or (c) for use in connection with the design, development or production of nuclear, chemical or biological weapons, or rocket systems, space launch vehicles, or sounding rockets, or unmanned air vehicle systems.",
       "narrative": "Rocky Linux in source code and binary code form is publicly available and is not subject to the EAR in accordance with §740.17(b)(1).",
       "product_title": "Product",
       "product_text": "Rocky Linux. Includes Rocky Linux Project \"Special Interest Group\" repositories.",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,25 @@ const nextConfig = {
       },
     ],
   },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        has: [
+          {
+            type: "host",
+            value: "staging.rockylinux.org",
+          },
+        ],
+        headers: [
+          {
+            key: "X-Robots-Tag",
+            value: "noindex",
+          },
+        ],
+      },
+    ];
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
This pull request introduces updates to localization and configuration files, primarily adding new device categories to the Japanese translations and implementing a header to prevent search engine indexing on the staging environment. Below are the most important changes:

**Localization updates:**

* Added new entries for `visionfive2Images` and `specializedDevices` under the device images section in the Japanese translation file `messages/ja-JP.json`, enabling support for these device categories in the UI.
* Minor formatting adjustment in the export compliance text in `messages/ja-JP.json` to use consistent quotation marks, improving text consistency.

**Configuration enhancements:**

* Updated `next.config.mjs` to add a custom header (`X-Robots-Tag: noindex`) for all requests to the staging environment (`staging.rockylinux.org`), preventing search engines from indexing the staging site.