### PR TITLE
Change close PR to always happen

### DIFF
--- a/.github/workflows/check-download-urls.yml
+++ b/.github/workflows/check-download-urls.yml
@@ -125,7 +125,7 @@ jobs:
             }
 
       - name: Close issue if URLs are fixed
-        if: steps.url-check.outcome == 'success'
+        if: steps.url-check.outcome == 'success' && github.event_name != 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/check-download-urls.yml
+++ b/.github/workflows/check-download-urls.yml
@@ -2,172 +2,172 @@ name: Check Download URLs
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
     paths:
-      - 'data/downloads.json'
+      - "data/downloads.json"
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
     paths:
-      - 'data/downloads.json'
+      - "data/downloads.json"
   schedule:
     # Run daily at 2 AM UTC to catch broken links
-    - cron: '0 2 * * *'
+    - cron: "0 2 * * *"
   workflow_dispatch:
     # Allow manual triggering
 
 jobs:
   check-urls:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-    
-    - name: Extract and check URLs
-      id: url-check
-      run: node scripts/check-download-urls.js
-      env:
-        GITHUB_ACTIONS: true
-      continue-on-error: true
-    
-    - name: Comment PR on failure
-      if: steps.url-check.outcome == 'failure' && github.event_name == 'pull_request'
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const fs = require('fs');
-          if (fs.existsSync('url-check-summary.md')) {
-            const summary = fs.readFileSync('url-check-summary.md', 'utf8');
-            
-            // Check for existing comments from this workflow
-            const comments = await github.rest.issues.listComments({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            });
-            
-            const botComment = comments.data.find(comment => 
-              comment.user.type === 'Bot' && 
-              comment.body.includes('🚨 URL Check Failed')
-            );
-            
-            if (botComment) {
-              // Update existing comment
-              await github.rest.issues.updateComment({
-                comment_id: botComment.id,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: summary + '\n\n*Updated: ' + new Date().toISOString() + '*'
-              });
-            } else {
-              // Create new comment
-              await github.rest.issues.createComment({
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Extract and check URLs
+        id: url-check
+        run: node scripts/check-download-urls.js
+        env:
+          GITHUB_ACTIONS: true
+        continue-on-error: true
+
+      - name: Comment PR on failure
+        if: steps.url-check.outcome == 'failure' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            if (fs.existsSync('url-check-summary.md')) {
+              const summary = fs.readFileSync('url-check-summary.md', 'utf8');
+              
+              // Check for existing comments from this workflow
+              const comments = await github.rest.issues.listComments({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: summary
+                repo: context.repo.repo
               });
+              
+              const botComment = comments.data.find(comment => 
+                comment.user.type === 'Bot' && 
+                comment.body.includes('🚨 URL Check Failed')
+              );
+              
+              if (botComment) {
+                // Update existing comment
+                await github.rest.issues.updateComment({
+                  comment_id: botComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: summary + '\n\n*Updated: ' + new Date().toISOString() + '*'
+                });
+              } else {
+                // Create new comment
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: summary
+                });
+              }
             }
-          }
-    
-    - name: Create or update issue on scheduled run failure
-      if: steps.url-check.outcome == 'failure' && github.event_name == 'schedule'
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const fs = require('fs');
-          let body = '## 🚨 Daily URL Check Failed\n\n';
-          
-          if (fs.existsSync('url-check-summary.md')) {
-            body += fs.readFileSync('url-check-summary.md', 'utf8');
-          } else {
-            body += 'The URL checker found broken links in downloads.json. Please check the workflow logs for details.';
-          }
-          
-          body += '\n\n[View latest workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})';
-          
-          // Check for existing open issues
-          const issues = await github.rest.issues.listForRepo({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            state: 'open',
-            labels: 'downloads,url-check-failed'
-          });
-          
-          const existingIssue = issues.data.find(issue => 
-            issue.title === 'Broken download URLs detected'
-          );
-          
-          if (existingIssue) {
-            // Add comment to existing issue
-            await github.rest.issues.createComment({
-              issue_number: existingIssue.number,
+
+      - name: Create or update issue on scheduled run failure
+        if: steps.url-check.outcome == 'failure' && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let body = '## 🚨 Daily URL Check Failed\n\n';
+
+            if (fs.existsSync('url-check-summary.md')) {
+              body += fs.readFileSync('url-check-summary.md', 'utf8');
+            } else {
+              body += 'The URL checker found broken links in downloads.json. Please check the workflow logs for details.';
+            }
+
+            body += '\n\n[View latest workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})';
+
+            // Check for existing open issues
+            const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: body + '\n\n*Check performed at: ' + new Date().toISOString() + '*'
+              state: 'open',
+              labels: 'downloads,url-check-failed'
             });
-            console.log(`Updated existing issue #${existingIssue.number}`);
-          } else {
-            // Create new issue
-            await github.rest.issues.create({
+
+            const existingIssue = issues.data.find(issue => 
+              issue.title === 'Broken download URLs detected'
+            );
+
+            if (existingIssue) {
+              // Add comment to existing issue
+              await github.rest.issues.createComment({
+                issue_number: existingIssue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body + '\n\n*Check performed at: ' + new Date().toISOString() + '*'
+              });
+              console.log(`Updated existing issue #${existingIssue.number}`);
+            } else {
+              // Create new issue
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'Broken download URLs detected',
+                body: body + '\n\n*First detected: ' + new Date().toISOString() + '*\n\nThis issue will be automatically updated with new checks until resolved.',
+                labels: ['bug', 'downloads', 'url-check-failed']
+              });
+              console.log('Created new issue for broken URLs');
+            }
+
+      - name: Close issue if URLs are fixed
+        if: steps.url-check.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Check for existing open issues
+            const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'Broken download URLs detected',
-              body: body + '\n\n*First detected: ' + new Date().toISOString() + '*\n\nThis issue will be automatically updated with new checks until resolved.',
-              labels: ['bug', 'downloads', 'url-check-failed']
+              state: 'open',
+              labels: ['downloads', 'url-check-failed']
             });
-            console.log('Created new issue for broken URLs');
-          }
-    
-    - name: Close issue if URLs are fixed
-      if: steps.url-check.outcome == 'success' && github.event_name == 'schedule'
-      uses: actions/github-script@v7
-      with:
-        script: |
-          // Check for existing open issues
-          const issues = await github.rest.issues.listForRepo({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            state: 'open',
-            labels: ['downloads', 'url-check-failed']
-          });
-          
-          const existingIssue = issues.data.find(issue => 
-            issue.title === 'Broken download URLs detected'
-          );
-          
-          if (existingIssue) {
-            // Close the issue
-            await github.rest.issues.update({
-              issue_number: existingIssue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'closed'
-            });
-            
-            // Add closing comment
-            await github.rest.issues.createComment({
-              issue_number: existingIssue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '✅ All URLs are now accessible! Closing this issue.\n\n*Verified at: ' + new Date().toISOString() + '*'
-            });
-            
-            console.log(`Closed issue #${existingIssue.number} - all URLs are fixed`);
-          }
-    
-    - name: Set workflow status
-      if: always()
-      run: |
-        if [ "${{ steps.url-check.outcome }}" == "failure" ]; then
-          echo "URL check failed - marking workflow as failed"
-          exit 1
-        else
-          echo "URL check passed"
-          exit 0
-        fi
+
+            const existingIssue = issues.data.find(issue => 
+              issue.title === 'Broken download URLs detected'
+            );
+
+            if (existingIssue) {
+              // Close the issue
+              await github.rest.issues.update({
+                issue_number: existingIssue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'closed'
+              });
+              
+              // Add closing comment
+              await github.rest.issues.createComment({
+                issue_number: existingIssue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: '✅ All URLs are now accessible! Closing this issue.\n\n*Verified at: ' + new Date().toISOString() + '*'
+              });
+              
+              console.log(`Closed issue #${existingIssue.number} - all URLs are fixed`);
+            }
+
+      - name: Set workflow status
+        if: always()
+        run: |
+          if [ "${{ steps.url-check.outcome }}" == "failure" ]; then
+            echo "URL check failed - marking workflow as failed"
+            exit 1
+          else
+            echo "URL check passed"
+            exit 0
+          fi


### PR DESCRIPTION
This pull request makes minor updates to the `.github/workflows/check-download-urls.yml` workflow file, focusing on consistency in YAML formatting and a small logic change for issue closing conditions.

Formatting improvements:

* Changed all single quotes to double quotes for string values in the workflow triggers and job steps to ensure consistency. [[1]](diffhunk://#diff-2a80cbe548a4847d29327e03c9f0fa1b30bd82620dcd7001034b2de73c741c82L7-R14) [[2]](diffhunk://#diff-2a80cbe548a4847d29327e03c9f0fa1b30bd82620dcd7001034b2de73c741c82L29-R29)

Logic update:

* Modified the condition for closing issues so that it only runs when the event is not a `pull_request`, instead of only when it's a scheduled event.