### PR TITLE
fix: update VisionFive2 links to vault archive

### DIFF
--- a/data/downloads.json
+++ b/data/downloads.json
@@ -458,7 +458,7 @@
               "minimalImage": "https://hub.docker.com/r/rockylinux/rockylinux/tags?name=10.1-minimal"
             },
             "visionfive2Images": {
-              "download": "https://dl.rockylinux.org/pub/rocky/10/images/riscv64/Rocky-10-VisionFive2-latest.riscv64.tar.xz"
+              "download": "https://dl.rockylinux.org/vault/rocky/10.0/images/riscv64/Rocky-10-VisionFive2-latest.riscv64.tar.xz"
             }
           },
           "links": {
@@ -472,7 +472,7 @@
               "checksum": "https://dl.rockylinux.org/pub/rocky/10/images/riscv64/CHECKSUM"
             },
             "visionfive2Images": {
-              "checksum": "https://dl.rockylinux.org/pub/rocky/10/images/riscv64/Rocky-10-VisionFive2-latest.riscv64.tar.xz.CHECKSUM"
+              "checksum": "https://dl.rockylinux.org/vault/rocky/10.0/images/riscv64/Rocky-10-VisionFive2-latest.riscv64.tar.xz.CHECKSUM"
             }
           }
         }

--- a/messages/en.json
+++ b/messages/en.json
@@ -260,7 +260,7 @@
         "readMe": "README"
       },
       "visionfive2Images": {
-        "title": "VisionFive 2 Images",
+        "title": "VisionFive 2 Images (Archived)",
         "download": "Download",
         "readMe": "README"
       },


### PR DESCRIPTION
## Summary
- Updated VisionFive2 download and checksum URLs to point to the 10.0 vault archive (images no longer available in main Rocky 10 repository)
- Added "(Archived)" label to the VisionFive 2 Images card title to indicate these are archived images

## Test plan
- [x] Run `npm run check:downloads` to verify all URLs return 200
- [x] Check the download page for riscv64 architecture to verify the VisionFive2 card displays correctly with "(Archived)" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)