### PR TITLE
Add Open Graph and JSON-LD metadata to news pages

### DIFF
--- a/app/[locale]/news/[slug]/page.tsx
+++ b/app/[locale]/news/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+
 import Date from "@/components/Date";
 import ShareButtons from "@/components/shareButtons/ShareButtons";
 
@@ -17,9 +19,10 @@ export type PostData = {
   date: string;
   author?: string;
   contentHtml: string;
+  excerpt: string;
 };
 
-export async function generateMetadata({ params }: Props) {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
 
   if (!(await checkIfSlugIsValid(slug))) {
@@ -29,9 +32,22 @@ export async function generateMetadata({ params }: Props) {
   }
 
   const postData: PostData = await getPostData(slug);
+  const url = `https://rockylinux.org/news/${slug}`;
+  const author = postData.author || "Rocky Linux Team";
 
   return {
     title: `${postData.title} - Rocky Linux`,
+    description: postData.excerpt,
+    openGraph: {
+      title: postData.title,
+      description: postData.excerpt,
+      url,
+      siteName: "Rocky Linux",
+      locale: "en_US",
+      type: "article",
+      publishedTime: postData.date,
+      authors: [author],
+    },
   };
 }
 

--- a/app/[locale]/news/[slug]/page.tsx
+++ b/app/[locale]/news/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Date from "@/components/Date";
 import ShareButtons from "@/components/shareButtons/ShareButtons";
 
 import { checkIfSlugIsValid, getPostData } from "@/lib/news";
+import { safeJsonLdStringify } from "@/utils/jsonLd";
 import { notFound } from "next/navigation";
 
 export type Params = {
@@ -59,25 +60,53 @@ export default async function Post({ params }: Props) {
   }
 
   const postData: PostData = await getPostData(slug);
+  const author = postData.author || "Rocky Linux Team";
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "NewsArticle",
+    headline: postData.title,
+    description: postData.excerpt,
+    datePublished: postData.date,
+    author: {
+      "@type": "Person",
+      name: author,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Rocky Linux",
+      url: "https://rockylinux.org",
+    },
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": `https://rockylinux.org/news/${slug}`,
+    },
+  };
 
   return (
-    <div className="py-24 sm:py-32">
-      <div className="mx-auto max-w-3xl text-base leading-7">
-        <p className="text-base font-semibold leading-7 text-primary text-center uppercase font-display">
-          <Date dateString={postData.date} />
-        </p>
-        <h1 className="mt-2 text-3xl font-bold tracking-tight sm:text-4xl mb-2 text-center font-display">
-          {postData.title}
-        </h1>
-        <p className="text-base leading-7 text-center mb-12 italic">
-          {postData.author ? postData.author : "Rocky Linux Team"}
-        </p>
-        <div
-          className="prose dark:prose-invert prose-headings:font-display prose-a:text-primary prose-pre:bg-muted prose-pre:py-3 prose-pre:px-4 prose-pre:rounded prose-pre:text-black dark:prose-pre:text-white prose-img:rounded-md max-w-none mb-12"
-          dangerouslySetInnerHTML={{ __html: postData.contentHtml }}
-        />
-        <ShareButtons url={`https://rockylinux.org/news/${slug}`} />
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
+      />
+      <div className="py-24 sm:py-32">
+        <div className="mx-auto max-w-3xl text-base leading-7">
+          <p className="text-base font-semibold leading-7 text-primary text-center uppercase font-display">
+            <Date dateString={postData.date} />
+          </p>
+          <h1 className="mt-2 text-3xl font-bold tracking-tight sm:text-4xl mb-2 text-center font-display">
+            {postData.title}
+          </h1>
+          <p className="text-base leading-7 text-center mb-12 italic">
+            {author}
+          </p>
+          <div
+            className="prose dark:prose-invert prose-headings:font-display prose-a:text-primary prose-pre:bg-muted prose-pre:py-3 prose-pre:px-4 prose-pre:rounded prose-pre:text-black dark:prose-pre:text-white prose-img:rounded-md max-w-none mb-12"
+            dangerouslySetInnerHTML={{ __html: postData.contentHtml }}
+          />
+          <ShareButtons url={`https://rockylinux.org/news/${slug}`} />
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/app/[locale]/news/page.tsx
+++ b/app/[locale]/news/page.tsx
@@ -1,4 +1,4 @@
-import type { NextPage, Route } from "next";
+import type { Metadata, NextPage, Route } from "next";
 
 import { getTranslations } from "next-intl/server";
 import Link from "next/link";
@@ -14,12 +14,22 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-export async function generateMetadata() {
+export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("news");
+  const title = t("title");
+  const description = t("description");
 
   return {
-    title: `${t("title")} - Rocky Linux`,
-    description: `${t("description")}`,
+    title: `${title} - Rocky Linux`,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: "https://rockylinux.org/news",
+      siteName: "Rocky Linux",
+      locale: "en_US",
+      type: "website",
+    },
   };
 }
 

--- a/lib/news.ts
+++ b/lib/news.ts
@@ -22,9 +22,7 @@ export async function checkIfSlugIsValid(slug: string) {
   }
 }
 
-export async function getSortedPostsData(
-  numPosts?: number
-): Promise<
+export async function getSortedPostsData(numPosts?: number): Promise<
   {
     slug: string;
     excerpt: string;
@@ -46,7 +44,7 @@ export async function getSortedPostsData(
 
       const contentHtml = await processMarkdownAsHTML(matterResult.content);
       const plainText = contentHtml.replace(/<[^>]*>/g, "");
-      const excerpt = plainText.substring(0, 200) + "...";
+      const excerpt = plainText.substring(0, 150) + "...";
 
       return {
         slug,
@@ -94,7 +92,7 @@ export async function getPostData(slug: string) {
   const contentHtml = await processMarkdownAsHTML(matterResult.content);
 
   const plainText = contentHtml.replace(/<[^>]*>/g, "");
-  const excerpt = plainText.substring(0, 200) + "...";
+  const excerpt = plainText.substring(0, 150) + "...";
 
   return {
     slug,

--- a/utils/__tests__/jsonLd.test.ts
+++ b/utils/__tests__/jsonLd.test.ts
@@ -1,0 +1,75 @@
+import { safeJsonLdStringify } from "../jsonLd";
+
+describe("safeJsonLdStringify", () => {
+  it("should stringify a simple object", () => {
+    const data = { name: "Test", value: 123 };
+    const result = safeJsonLdStringify(data);
+    expect(result).toBe('{"name":"Test","value":123}');
+  });
+
+  it("should escape < characters to prevent script injection", () => {
+    const data = { title: "<script>alert('xss')</script>" };
+    const result = safeJsonLdStringify(data);
+    expect(result).not.toContain("<");
+    expect(result).toContain("\\u003c");
+  });
+
+  it("should escape > characters to prevent script injection", () => {
+    const data = { title: "test</script><script>alert('xss')" };
+    const result = safeJsonLdStringify(data);
+    expect(result).not.toContain(">");
+    expect(result).toContain("\\u003e");
+  });
+
+  it("should escape & characters to prevent HTML entity issues", () => {
+    const data = { title: "Rocky & Linux" };
+    const result = safeJsonLdStringify(data);
+    expect(result).not.toContain("&");
+    expect(result).toContain("\\u0026");
+  });
+
+  it("should escape all dangerous characters in complex content", () => {
+    const data = {
+      title: "<script>alert('xss')</script>",
+      description: "Test & verify > safety < concerns",
+    };
+    const result = safeJsonLdStringify(data);
+    expect(result).not.toContain("<");
+    expect(result).not.toContain(">");
+    expect(result).not.toContain("&");
+  });
+
+  it("should handle nested objects", () => {
+    const data = {
+      "@context": "https://schema.org",
+      author: {
+        "@type": "Person",
+        name: "Test <Author>",
+      },
+    };
+    const result = safeJsonLdStringify(data);
+    expect(result).not.toContain("<");
+    expect(result).not.toContain(">");
+  });
+
+  it("should handle arrays", () => {
+    const data = {
+      tags: ["<script>", "test & tag", "normal"],
+    };
+    const result = safeJsonLdStringify(data);
+    expect(result).not.toContain("<");
+    expect(result).not.toContain("&");
+  });
+
+  it("should produce valid JSON when parsed (after unescaping)", () => {
+    const data = {
+      "@context": "https://schema.org",
+      "@type": "NewsArticle",
+      headline: "Test Article",
+      datePublished: "2025-01-01",
+    };
+    const result = safeJsonLdStringify(data);
+    // The escaped output should still be valid JSON
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+});

--- a/utils/jsonLd.ts
+++ b/utils/jsonLd.ts
@@ -1,0 +1,7 @@
+/**
+ * Sanitizes and stringifies an object for safe use in JSON-LD script tags.
+ * Prevents XSS by escaping characters that could break out of the script context.
+ */
+export function safeJsonLdStringify(data: Record<string, unknown>): string {
+  return JSON.stringify(data).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
+}

--- a/utils/jsonLd.ts
+++ b/utils/jsonLd.ts
@@ -3,5 +3,8 @@
  * Prevents XSS by escaping characters that could break out of the script context.
  */
 export function safeJsonLdStringify(data: Record<string, unknown>): string {
-  return JSON.stringify(data).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
+  return JSON.stringify(data)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
 }


### PR DESCRIPTION
## Summary
- Add Open Graph protocol meta tags to `/news` listing and `/news/[slug]` article pages for better social media sharing
- Add JSON-LD structured data (NewsArticle schema) to article pages for improved Google Search indexing
- Include sanitized JSON-LD utility function to prevent XSS from malicious PR contributions

## Test plan
- [ ] Verify OG tags render correctly in page source on news listing page
- [ ] Verify OG tags render correctly in page source on individual article pages
- [ ] Validate JSON-LD with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Test social sharing preview with [OpenGraph.xyz](https://www.opengraph.xyz/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)