### PR TITLE
update: update gpg page with keys and updated info

### DIFF
--- a/resources/gpg-key-info.md
+++ b/resources/gpg-key-info.md
@@ -5,13 +5,13 @@ description: "This document contains information on how we use GPG keys."
 
 ## How Rocky Linux uses GPG keys
 
-Each stable RPM package that is published by Rocky Linux is signed with a GPG signature. By default, `yum` and the graphical update tools will verify these signatures and refuse to install any packages that are not signed, or have an incorrect signature. You should always verify the signature of the package prior to installation. These signatures ensure that the packages you install are what was produced by Rocky Linux and have not been altered by any mirror or website providing the packages.
+Each stable RPM package that is published by Rocky Linux is signed with a GPG signature. By default, `dnf` and the graphical update tools will verify these signatures and refuse to install any packages that are not signed, or have an incorrect signature. You should always verify the signature of the package prior to installation. These signatures ensure that the packages you install are what was produced by Rocky Linux and have not been altered by any mirror or website providing the packages.
 
 ---
 
 ## Importing Keys
 
-The Project GPG keys are included in the `rockylinux-release` package, and are typically found in `/etc/pki/rpm-gpg`. Please note that not all keys in this directory are used by the Rocky Linux project. Some keys may be placed in this directory by 3rd party repositories to enable the secure use of extra packages, as well. The keys used by Rocky Linux are enabled in the `yum` repository configuration, so you generally don't need to manually import them.
+The Project GPG keys are included in the `rocky-gpg-keys` package, and are typically found in `/etc/pki/rpm-gpg`. Please note that not all keys in this directory are used by the Rocky Linux project. Some keys may be placed in this directory by 3rd party repositories to enable the secure use of extra packages, as well. The keys used by Rocky Linux are enabled in the system repository configuration typically found in `/etc/yum.repos.d`, so you generally don't need to manually import them.
 
 If you want to verify that the keys installed on your system match the keys listed here, you can use GnuPG to check that the key fingerprint matches. For example:
 
@@ -20,6 +20,13 @@ gpg --quiet --show-keys /etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial
 pub   rsa4096 2021-02-14 [SCE]
       7051C470A929F454CEBE37B715AF5DAC6D745A60
 uid           Release Engineering <infrastructure@rockylinux.org>
+```
+
+```
+gpg --quiet --show-keys /etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-10
+pub   rsa4096 2025-05-19 [SCE]
+      FC226859C0860BF0DDB95B085B106C736FEDFC85
+uid                      Release Engineering (Rocky Linux 10) <releng@rockylinux.org>
 ```
 
 ---
@@ -48,6 +55,15 @@ pub   rsa4096/0x702D426D350D275D 2022-05-09 Rocky Enterprise Software Foundation
 Key Fingerprint = 21CB 256A E16F C54C 6E65 2949 702D 426D 350D 275D
 ```
 
+#### Rocky Linux 10
+
+[Download Key](https://dl.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-10)
+
+```
+pub   rsa4096/0x5B106C736FEDFC85 Release Engineering (Rocky Linux 10) <releng@rockylinux.org>
+Key Fingerprint = FC22 6859 C086 0BF0 DDB9 5B08 5B10 6C73 6FED FC85
+```
+
 ### Rocky Linux Testing Keys
 
 #### Rocky Linux 8
@@ -68,6 +84,15 @@ pub   rsa4096/0xADA2860895AE3D91 2022-04-26 Rocky Linux 9 - Beta Key V1/2022 <re
 Key fingerprint = 0675 BD19 F4FF E3AD 0B2D 6FEB ADA2 8608 95AE 3D91
 ```
 
+#### Rocky Linux 10
+
+[Download Key](https://dl.rockylinux.org/pub/rocky/RPM-GPG-KEY-Rocky-10-Testing)
+
+```
+pub   rsa4096/0x4C360B7022B7FA33 Release Engineering (Rocky Linux 10 Testing) <releng@rockylinux.org>
+Key Fingerprint = BFAE 243E DEF0 5301 91A2 2631 4C36 0B70 22B7 FA33
+```
+
 ### Rocky Linux Infrastructure Keys
 
 #### Rocky Linux 8
@@ -80,5 +105,9 @@ Key fingerprint = BFC3 D8F2 0D15 F4FD 4628  1D7F AA65 0F52 D6C0 94FA
 ```
 
 #### Rocky Linux 9
+
+Not applicable.
+
+#### Rocky Linux 10
 
 Not applicable.


### PR DESCRIPTION
Update the GPG keys as they are missing Rocky Linux 10. Also minor clarifications on where the keys are in our packages.