### PR TITLE
Fix locale-aware navigation using next-intl Link

### DIFF
--- a/app/[locale]/Footer.tsx
+++ b/app/[locale]/Footer.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from "next-intl";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import { JSX, SVGProps, Suspense } from "react";
 import LanguagePickerWrapper from "@/components/LanguagePickerWrapper";
 import type { Route } from "next";

--- a/app/[locale]/Header.tsx
+++ b/app/[locale]/Header.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from "next-intl";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 import Logo from "@/components/Logo";
 import { Button } from "@/components/ui/button";

--- a/app/[locale]/Hero.tsx
+++ b/app/[locale]/Hero.tsx
@@ -4,7 +4,7 @@ import DpgLogo from "@/components/otherLogosIcons/DpgLogo";
 
 import { Button } from "@/components/ui/button";
 import React from "react";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 const Hero = () => {
   const t = useTranslations("home.hero");

--- a/app/[locale]/NewsSnippet.tsx
+++ b/app/[locale]/NewsSnippet.tsx
@@ -1,5 +1,5 @@
 import { getTranslations } from "next-intl/server";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import { format } from "date-fns";
 
 import { getSortedPostsData } from "@/lib/news";

--- a/app/[locale]/about/page.tsx
+++ b/app/[locale]/about/page.tsx
@@ -1,7 +1,7 @@
 import LogoCloud from "@/components/logoCloud/LogoCloud";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/[locale]/community/page.tsx
+++ b/app/[locale]/community/page.tsx
@@ -1,5 +1,5 @@
 import { getTranslations, setRequestLocale } from "next-intl/server";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import type { Metadata } from "next";
 import Quiz from "./components/Quiz";
 import { QuizInterests } from "./components/QuizInterestTypes";

--- a/app/[locale]/components/header/MobileNavigation.tsx
+++ b/app/[locale]/components/header/MobileNavigation.tsx
@@ -7,7 +7,7 @@ import {
   SheetClose,
 } from "@/components/ui/sheet";
 import { Accordion } from "@/components/ui/accordion";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 import { Button } from "@/components/ui/button";
 import Logo from "@/components/Logo";

--- a/app/[locale]/components/header/nav/desktop/NavItem.tsx
+++ b/app/[locale]/components/header/nav/desktop/NavItem.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 import {
   NavigationMenuItem,

--- a/app/[locale]/components/header/nav/desktop/NavListItem.tsx
+++ b/app/[locale]/components/header/nav/desktop/NavListItem.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils";
 
 import { NavigationMenuLink } from "@/components/ui/navigation-menu";
+import { Link } from "@/i18n/navigation";
 
 export interface NavListItemProps {
   title: string;
@@ -9,17 +10,15 @@ export interface NavListItemProps {
 
 const NavListItem = ({ title, href }: NavListItemProps) => {
   return (
-    <NavigationMenuLink
-      title={title}
-      href={href}
-    >
-      <a
+    <NavigationMenuLink asChild>
+      <Link
+        href={href}
         className={cn(
           "block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
         )}
       >
         <div className="text-sm font-medium leading-none">{title}</div>
-      </a>
+      </Link>
     </NavigationMenuLink>
   );
 };

--- a/app/[locale]/components/header/nav/mobile/NavItem.tsx
+++ b/app/[locale]/components/header/nav/mobile/NavItem.tsx
@@ -1,6 +1,6 @@
 import { SheetClose } from "@/components/ui/sheet";
 import { Route } from "next";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 export interface NavItemProps<T extends string> {
   title: string;

--- a/app/[locale]/components/header/nav/mobile/NavListItem.tsx
+++ b/app/[locale]/components/header/nav/mobile/NavListItem.tsx
@@ -1,6 +1,6 @@
 import { SheetClose } from "@/components/ui/sheet";
 import { Route } from "next";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 export interface NavListItemProps<T extends string> {
   title: string;

--- a/app/[locale]/download/components/CloudImage/Card.tsx
+++ b/app/[locale]/download/components/CloudImage/Card.tsx
@@ -20,7 +20,7 @@ import {
 import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 import { Tabs } from "@/components/ui/tabs";
 import VersionPicker from "./VersionPicker";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 import { CloudImage, Columns } from "./Table/Columns";
 import { DataTable } from "./Table/DataTable";

--- a/app/[locale]/news/[slug]/not-found.tsx
+++ b/app/[locale]/news/[slug]/not-found.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import { useTranslations } from "next-intl";
 
 export default function SlugNotFound() {

--- a/app/[locale]/news/page.tsx
+++ b/app/[locale]/news/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata, Route } from "next";
 
 import { getTranslations, setRequestLocale } from "next-intl/server";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import { format } from "date-fns";
 
 import { getSortedPostsData } from "@/lib/news";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,18 @@ const eslintConfig = defineConfig([
       "@typescript-eslint/no-explicit-any": "error",
       "no-undef": "off", // TypeScript handles this
       "no-duplicate-imports": "error",
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "next/link",
+              message:
+                "Use `import { Link } from '@/i18n/navigation'` instead to ensure locale-aware routing.",
+            },
+          ],
+        },
+      ],
       "react/no-unescaped-entities": ["error", { forbid: [">", "}"] }],
       "react/jsx-no-literals": ["warn", { noStrings: true, ignoreProps: true }],
     },
@@ -84,6 +96,18 @@ const eslintConfig = defineConfig([
       ],
       "no-undef": "error",
       "no-duplicate-imports": "error",
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "next/link",
+              message:
+                "Use `import { Link } from '@/i18n/navigation'` instead to ensure locale-aware routing.",
+            },
+          ],
+        },
+      ],
       "react/no-unescaped-entities": ["error", { forbid: [">", "}"] }],
       "react/jsx-no-literals": ["warn", { noStrings: true, ignoreProps: true }],
     },

--- a/i18n/navigation.ts
+++ b/i18n/navigation.ts
@@ -1,0 +1,5 @@
+import { createNavigation } from "next-intl/navigation";
+import { routing } from "./routing";
+
+export const { Link, redirect, usePathname, useRouter, getPathname } =
+  createNavigation(routing);

--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -2,7 +2,7 @@ import { defineRouting } from "next-intl/routing";
 import { availableLanguages, defaultLanguage } from "@/config/i18nProperties";
 
 export const routing = defineRouting({
-  locales: [...availableLanguages],
+  locales: availableLanguages,
   defaultLocale: defaultLanguage,
   localePrefix: "as-needed",
 });

--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -1,0 +1,8 @@
+import { defineRouting } from "next-intl/routing";
+import { availableLanguages, defaultLanguage } from "@/config/i18nProperties";
+
+export const routing = defineRouting({
+  locales: [...availableLanguages],
+  defaultLocale: defaultLanguage,
+  localePrefix: "as-needed",
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,8 @@
 import createMiddleware from "next-intl/middleware";
-import { availableLanguages } from "./config/i18nProperties";
+import { routing } from "./i18n/routing";
 
 export default createMiddleware({
-  // A list of all locales that are supported
-  locales: [...availableLanguages],
-  localePrefix: "as-needed",
-  defaultLocale: "en",
+  ...routing,
   // Disable Accept-Language header detection to enable static rendering
   // See: docs/i18n/caching-and-locale-detection.md
   localeDetection: false,


### PR DESCRIPTION
## Summary
- Replace all `next/link` imports with locale-aware `Link` from `next-intl/navigation` so internal links preserve the current locale prefix (e.g. `/fr-FR/download` instead of `/download`)
- Add shared routing config (`i18n/routing.ts`) and navigation exports (`i18n/navigation.ts`) using `defineRouting` / `createNavigation` from next-intl
- Update `middleware.ts` to reuse the shared routing config
- Add ESLint `no-restricted-imports` rule to error on direct `next/link` imports, preventing future regressions

## Test plan
- [ ] Visit the site with a non-English locale (e.g. `/fr-FR/`)
- [ ] Click the Download button on the hero — verify it navigates to `/fr-FR/download` not `/download`
- [ ] Click navigation links (header, footer, mobile nav) — verify locale is preserved
- [ ] Verify English (`/`) still works without a locale prefix
- [ ] Run `npm run lint` — verify no `next/link` import errors
- [ ] Run `npm run build` — verify build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)