### PR TITLE
Merge develop: i18n locale-aware links and translation updates

### DIFF
--- a/app/[locale]/Footer.tsx
+++ b/app/[locale]/Footer.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from "next-intl";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import { JSX, SVGProps, Suspense } from "react";
 import LanguagePickerWrapper from "@/components/LanguagePickerWrapper";
 import type { Route } from "next";

--- a/app/[locale]/Header.tsx
+++ b/app/[locale]/Header.tsx
@@ -1,5 +1,5 @@
 import { useTranslations } from "next-intl";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 import Logo from "@/components/Logo";
 import { Button } from "@/components/ui/button";

--- a/app/[locale]/Hero.tsx
+++ b/app/[locale]/Hero.tsx
@@ -4,7 +4,7 @@ import DpgLogo from "@/components/otherLogosIcons/DpgLogo";
 
 import { Button } from "@/components/ui/button";
 import React from "react";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 const Hero = () => {
   const t = useTranslations("home.hero");

--- a/app/[locale]/NewsSnippet.tsx
+++ b/app/[locale]/NewsSnippet.tsx
@@ -1,5 +1,5 @@
 import { getTranslations } from "next-intl/server";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import { format } from "date-fns";
 
 import { getSortedPostsData } from "@/lib/news";

--- a/app/[locale]/about/page.tsx
+++ b/app/[locale]/about/page.tsx
@@ -1,7 +1,7 @@
 import LogoCloud from "@/components/logoCloud/LogoCloud";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {

--- a/app/[locale]/community/page.tsx
+++ b/app/[locale]/community/page.tsx
@@ -1,5 +1,5 @@
 import { getTranslations, setRequestLocale } from "next-intl/server";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import type { Metadata } from "next";
 import Quiz from "./components/Quiz";
 import { QuizInterests } from "./components/QuizInterestTypes";

--- a/app/[locale]/components/header/MobileNavigation.tsx
+++ b/app/[locale]/components/header/MobileNavigation.tsx
@@ -7,7 +7,7 @@ import {
   SheetClose,
 } from "@/components/ui/sheet";
 import { Accordion } from "@/components/ui/accordion";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 import { Button } from "@/components/ui/button";
 import Logo from "@/components/Logo";

--- a/app/[locale]/components/header/nav/desktop/NavItem.tsx
+++ b/app/[locale]/components/header/nav/desktop/NavItem.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 import {
   NavigationMenuItem,

--- a/app/[locale]/components/header/nav/desktop/NavListItem.tsx
+++ b/app/[locale]/components/header/nav/desktop/NavListItem.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils";
 
 import { NavigationMenuLink } from "@/components/ui/navigation-menu";
+import { Link } from "@/i18n/navigation";
 
 export interface NavListItemProps {
   title: string;
@@ -9,17 +10,15 @@ export interface NavListItemProps {
 
 const NavListItem = ({ title, href }: NavListItemProps) => {
   return (
-    <NavigationMenuLink
-      title={title}
-      href={href}
-    >
-      <a
+    <NavigationMenuLink asChild>
+      <Link
+        href={href}
         className={cn(
           "block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
         )}
       >
         <div className="text-sm font-medium leading-none">{title}</div>
-      </a>
+      </Link>
     </NavigationMenuLink>
   );
 };

--- a/app/[locale]/components/header/nav/mobile/NavItem.tsx
+++ b/app/[locale]/components/header/nav/mobile/NavItem.tsx
@@ -1,6 +1,6 @@
 import { SheetClose } from "@/components/ui/sheet";
 import { Route } from "next";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 export interface NavItemProps<T extends string> {
   title: string;

--- a/app/[locale]/components/header/nav/mobile/NavListItem.tsx
+++ b/app/[locale]/components/header/nav/mobile/NavListItem.tsx
@@ -1,6 +1,6 @@
 import { SheetClose } from "@/components/ui/sheet";
 import { Route } from "next";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 export interface NavListItemProps<T extends string> {
   title: string;

--- a/app/[locale]/download/components/CloudImage/Card.tsx
+++ b/app/[locale]/download/components/CloudImage/Card.tsx
@@ -20,7 +20,7 @@ import {
 import { QuestionMarkCircledIcon } from "@radix-ui/react-icons";
 import { Tabs } from "@/components/ui/tabs";
 import VersionPicker from "./VersionPicker";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 
 import { CloudImage, Columns } from "./Table/Columns";
 import { DataTable } from "./Table/DataTable";

--- a/app/[locale]/news/[slug]/not-found.tsx
+++ b/app/[locale]/news/[slug]/not-found.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import { useTranslations } from "next-intl";
 
 export default function SlugNotFound() {

--- a/app/[locale]/news/page.tsx
+++ b/app/[locale]/news/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata, Route } from "next";
 
 import { getTranslations, setRequestLocale } from "next-intl/server";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import { format } from "date-fns";
 
 import { getSortedPostsData } from "@/lib/news";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,18 @@ const eslintConfig = defineConfig([
       "@typescript-eslint/no-explicit-any": "error",
       "no-undef": "off", // TypeScript handles this
       "no-duplicate-imports": "error",
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "next/link",
+              message:
+                "Use `import { Link } from '@/i18n/navigation'` instead to ensure locale-aware routing.",
+            },
+          ],
+        },
+      ],
       "react/no-unescaped-entities": ["error", { forbid: [">", "}"] }],
       "react/jsx-no-literals": ["warn", { noStrings: true, ignoreProps: true }],
     },
@@ -84,6 +96,18 @@ const eslintConfig = defineConfig([
       ],
       "no-undef": "error",
       "no-duplicate-imports": "error",
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "next/link",
+              message:
+                "Use `import { Link } from '@/i18n/navigation'` instead to ensure locale-aware routing.",
+            },
+          ],
+        },
+      ],
       "react/no-unescaped-entities": ["error", { forbid: [">", "}"] }],
       "react/jsx-no-literals": ["warn", { noStrings: true, ignoreProps: true }],
     },

--- a/i18n/navigation.ts
+++ b/i18n/navigation.ts
@@ -1,0 +1,5 @@
+import { createNavigation } from "next-intl/navigation";
+import { routing } from "./routing";
+
+export const { Link, redirect, usePathname, useRouter, getPathname } =
+  createNavigation(routing);

--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -2,7 +2,7 @@ import { defineRouting } from "next-intl/routing";
 import { availableLanguages, defaultLanguage } from "@/config/i18nProperties";
 
 export const routing = defineRouting({
-  locales: [...availableLanguages],
+  locales: availableLanguages,
   defaultLocale: defaultLanguage,
   localePrefix: "as-needed",
 });

--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -1,0 +1,8 @@
+import { defineRouting } from "next-intl/routing";
+import { availableLanguages, defaultLanguage } from "@/config/i18nProperties";
+
+export const routing = defineRouting({
+  locales: [...availableLanguages],
+  defaultLocale: defaultLanguage,
+  localePrefix: "as-needed",
+});

--- a/messages/ta-IN.json
+++ b/messages/ta-IN.json
@@ -4,12 +4,12 @@
     "download": "பதிவிறக்கு",
     "notFound": {
       "title": "கிடைக்கவில்லை",
-      "description": "The page you are looking for does not exist. Please check the URL and try again."
+      "description": "நீங்கள் தேடும் பக்கம் இல்லை. முகவரியைச் சரிபார்த்து மீண்டும் முயற்சி செய்."
     },
     "close": "மூடு"
   },
   "header": {
-    "toggleTheme": "Toggle Theme",
+    "toggleTheme": "கருப்பொருள் நிலைமாற்று",
     "nav": {
       "newsName": "செய்தி",
       "aboutName": "பற்றி",
@@ -21,7 +21,7 @@
       "about": {
         "about": "ராக்கி லினக்ச் பற்றி",
         "charter": "சமூக விதிமுறை",
-        "wiki": "Project Wiki",
+        "wiki": "விக்கி திட்டம்",
         "sponsors": "ஆதரவாளர்கள்",
         "partners": "பங்காளிகள்"
       },

--- a/messages/ta-IN.json
+++ b/messages/ta-IN.json
@@ -17,7 +17,7 @@
       "communityName": "சமூகம்",
       "supportName": "உதவி",
       "contributeName": "பங்களி",
-      "openMainMenu": "Open Main Menu",
+      "openMainMenu": "முதன்மை பட்டியலைத் திற",
       "about": {
         "about": "ராக்கி லினக்ச் பற்றி",
         "charter": "சமூக விதிமுறை",
@@ -42,7 +42,7 @@
         "supportProviders": "வணிகரீதியான ஆதரவு"
       },
       "contribute": {
-        "contribute": "Contributing Guide",
+        "contribute": "பங்களிப்பு வழிக்காட்டி",
         "shop": "கடை",
         "donate": "நன்கொடை"
       }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,8 @@
 import createMiddleware from "next-intl/middleware";
-import { availableLanguages } from "./config/i18nProperties";
+import { routing } from "./i18n/routing";
 
 export default createMiddleware({
-  // A list of all locales that are supported
-  locales: [...availableLanguages],
-  localePrefix: "as-needed",
-  defaultLocale: "en",
+  ...routing,
   // Disable Accept-Language header detection to enable static rendering
   // See: docs/i18n/caching-and-locale-detection.md
   localeDetection: false,


### PR DESCRIPTION
## Summary

- Fix locale-aware navigation across the site by switching to next-intl's `Link` component, ensuring all internal links respect the current locale
- Preserve locale literal types in routing config for better type safety
- Fix desktop `NavListItem` to properly use locale-aware links
- Add ESLint rule to enforce usage of next-intl `Link` over next/link
- Update Tamil (ta-IN) translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)