### PR TITLE
Fix e2e language picker selectors for translated aria-labels

### DIFF
--- a/docs/e2e/testing-patterns.md
+++ b/docs/e2e/testing-patterns.md
@@ -27,10 +27,11 @@ Radix Select portals its dropdown listbox to `document.body`. This means:
 **Solution:** Follow the `aria-controls` attribute from the combobox trigger to find its specific listbox by ID:
 
 ```typescript
-// After clicking to open the select
-const expandedPicker = page.locator(
-  '[role="combobox"][aria-label="Select language"][aria-expanded="true"]'
-);
+// After clicking to open the select — scope to the footer to avoid
+// hardcoding a translated aria-label
+const expandedPicker = page
+  .getByRole("contentinfo")
+  .locator('[role="combobox"][aria-expanded="true"]');
 const listboxId = await expandedPicker.getAttribute("aria-controls");
 const listbox = page.locator(`[id="${listboxId}"]`);
 ```
@@ -102,9 +103,9 @@ This requires adding `aria-label` to components that don't have visible labels. 
 Put component interaction helpers in `e2e/utils/PageUtils.ts` when the component is global (appears on every page) or will be tested from multiple spec files:
 
 ```typescript
-// e2e/utils/PageUtils.ts
+// e2e/utils/PageUtils.ts — scoped to footer so it works on all locales
 export const getLanguagePicker = (page: Page): Locator => {
-  return page.getByRole("combobox", { name: LANGUAGE_PICKER_LABEL });
+  return page.getByRole("contentinfo").getByRole("combobox");
 };
 
 export const openLanguagePicker = async (page: Page): Promise<Locator> => { ... };
@@ -191,9 +192,7 @@ page.getByRole("combobox", { name: "Select language" });
 page.getByRole("combobox", { name: "Select architecture" });
 ```
 
-**Exception:** Language switcher tests (`LanguageSwitcher.spec.ts`) navigate to non-English locales (`/fr-FR/`, `/de-DE/`, `/af-ZA/`) to verify locale switching and translated content. Once Crowdin populates translations for aria-label keys (e.g., `selectLanguage`), selectors using English accessible names will not match on non-English pages. If a language switcher test needs to interact with a localized component after navigating away from English, scope the selector by container or use a non-localized attribute instead of an accessible name.
-
-For tests that stay in the English locale, English constants (e.g., `LANGUAGE_PICKER_LABEL` in `PageUtils.ts`) remain correct.
+**Language picker:** The `getLanguagePicker` helper in `PageUtils.ts` scopes the combobox lookup to the footer (`contentinfo` role) instead of matching by accessible name. This avoids breaking when Crowdin translates the `selectLanguage` key — the footer only has one combobox, so the scoped query is unambiguous across all locales.
 
 ### `getAttribute()` Does Not Auto-Scroll
 

--- a/docs/e2e/testing-patterns.md
+++ b/docs/e2e/testing-patterns.md
@@ -31,6 +31,9 @@ Radix Select portals its dropdown listbox to `document.body`. This means:
 const picker = page.getByRole("contentinfo").getByRole("combobox");
 await picker.scrollIntoViewIfNeeded();
 const listboxId = await picker.getAttribute("aria-controls");
+if (!listboxId) {
+  throw new Error("Combobox is missing required aria-controls attribute");
+}
 
 await picker.click();
 const listbox = page.locator(`[id="${listboxId}"]`);

--- a/docs/e2e/testing-patterns.md
+++ b/docs/e2e/testing-patterns.md
@@ -24,20 +24,21 @@ Radix Select portals its dropdown listbox to `document.body`. This means:
 - `trigger.locator('[role="listbox"]')` will **not** work
 - `page.getByLabel('...').getByRole('listbox')` will **not** work (scopes to DOM children)
 
-**Solution:** Follow the `aria-controls` attribute from the combobox trigger to find its specific listbox by ID:
+**Solution:** Read the `aria-controls` attribute from the combobox trigger **before** clicking — Radix sets it even when the dropdown is closed. This avoids a re-query issue where Radix's portal overlay prevents Playwright from finding the trigger after the dropdown opens.
 
 ```typescript
-// After clicking to open the select — scope to the footer to avoid
-// hardcoding a translated aria-label
-const expandedPicker = page
-  .getByRole("contentinfo")
-  .locator('[role="combobox"][aria-expanded="true"]');
-const listboxId = await expandedPicker.getAttribute("aria-controls");
+// Read aria-controls before clicking — Radix sets it even when closed
+const picker = page.getByRole("contentinfo").getByRole("combobox");
+await picker.scrollIntoViewIfNeeded();
+const listboxId = await picker.getAttribute("aria-controls");
+
+await picker.click();
 const listbox = page.locator(`[id="${listboxId}"]`);
 ```
 
 This approach:
 
+- Reads `aria-controls` pre-click, avoiding post-click re-query issues
 - Uniquely identifies the listbox even if multiple selects exist on the page
 - Follows the actual ARIA relationship Radix establishes
 - Works regardless of where Radix portals the content

--- a/e2e/utils/PageUtils.ts
+++ b/e2e/utils/PageUtils.ts
@@ -1,9 +1,10 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
-const LANGUAGE_PICKER_LABEL = "Select language";
-
 /**
  * Returns a locator for the language picker combobox in the footer.
+ *
+ * Scoped to the footer (`contentinfo` role) so the lookup works regardless
+ * of the translated `aria-label` value.
  *
  * @param {Page} page - The Playwright page object.
  * @returns {Locator} A locator targeting the language picker combobox.
@@ -15,7 +16,7 @@ const LANGUAGE_PICKER_LABEL = "Select language";
  * ```
  */
 export const getLanguagePicker = (page: Page): Locator => {
-  return page.getByRole("combobox", { name: LANGUAGE_PICKER_LABEL });
+  return page.getByRole("contentinfo").getByRole("combobox");
 };
 
 /**
@@ -40,17 +41,17 @@ export const getLanguagePicker = (page: Page): Locator => {
  */
 export const openLanguagePicker = async (page: Page): Promise<Locator> => {
   const picker = getLanguagePicker(page);
-  await picker.click();
 
-  // Follow aria-controls to find the exact portaled listbox belonging
-  // to this combobox (Radix portals it to the body, so DOM traversal won't work)
-  const expandedPicker = page.locator(
-    `[role="combobox"][aria-label="${LANGUAGE_PICKER_LABEL}"][aria-expanded="true"]`
-  );
-  const listboxId = await expandedPicker.getAttribute("aria-controls");
+  // Read aria-controls before clicking — Radix sets it even when closed,
+  // and after the click Playwright may not be able to re-query the element
+  // within the footer (Radix portal overlay can interfere).
+  await picker.scrollIntoViewIfNeeded();
+  const listboxId = await picker.getAttribute("aria-controls");
   if (!listboxId) {
-    throw new Error("Language picker has no aria-controls after opening");
+    throw new Error("Language picker has no aria-controls attribute");
   }
+
+  await picker.click();
 
   const listbox = page.locator(`[id="${listboxId}"]`);
   await expect(listbox).toBeVisible();

--- a/e2e/utils/PageUtils.ts
+++ b/e2e/utils/PageUtils.ts
@@ -22,13 +22,15 @@ export const getLanguagePicker = (page: Page): Locator => {
 /**
  * Opens the language picker dropdown and returns a locator for its listbox.
  *
- * Clicks the combobox trigger, then follows the {@link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls aria-controls}
- * attribute to locate the exact portaled listbox. This is necessary because
- * Radix UI renders the listbox outside the trigger's DOM tree.
+ * Reads the {@link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls aria-controls}
+ * attribute before clicking to locate the exact portaled listbox, then clicks
+ * to open the dropdown. Reading `aria-controls` pre-click avoids a re-query
+ * issue where Radix's portal overlay prevents Playwright from finding the
+ * trigger element after the dropdown opens.
  *
  * @param {Page} page - The Playwright page object.
  * @returns {Promise<Locator>} A locator targeting the opened listbox element.
- * @throws {Error} If the combobox has no `aria-controls` attribute after opening.
+ * @throws {Error} If the combobox has no `aria-controls` attribute.
  *
  * @see {@link https://github.com/radix-ui/primitives/issues/2288 Radix open-close race condition}
  * @see [Testing Patterns](../../docs/e2e/testing-patterns.md) for full context on Radix Select gotchas.


### PR DESCRIPTION
## Summary
- Scopes language picker combobox lookup to the footer (`contentinfo` role) instead of matching by the hardcoded `"Select language"` accessible name, which breaks when Crowdin translates the `selectLanguage` key
- Reads `aria-controls` before clicking to avoid Radix portal re-query issues
- Updates e2e testing patterns doc to reflect the new approach

## Context
PR #279 (Crowdin translations) translates `selectLanguage` in French and German, causing all language switcher e2e tests to timeout on non-English pages.

## Test plan
- [x] 66/66 language switcher e2e tests pass across all browsers with translated strings merged in
- [x] Verified fix works with FR (`"Sélectionnez une langue"`) and DE (`"Sprache auswählen"`) translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)