### PR TITLE
Fix broken Muckles merch store URL

### DIFF
--- a/app/[locale]/contribute/shop/page.tsx
+++ b/app/[locale]/contribute/shop/page.tsx
@@ -23,7 +23,7 @@ const vendors = [
     name: "Muckles' U!",
     role: "Ships worldwide, based in US",
     imageUrl: "/images/shop/muckles-u.png",
-    link: "https://www.mucklesu.com/collections/rocky-linux",
+    link: "https://rockylinuxmerch.com/",
   },
   {
     name: "HELLOTUX",


### PR DESCRIPTION
## Summary
- Update the Muckles vendor link on the Shop page from the old `mucklesu.com` URL (which redirects to their general page) to the new dedicated store at `https://rockylinuxmerch.com/`

Fixes #281

## Test plan
- [x] Visit `/contribute/shop` and click the Muckles vendor card
- [x] Verify it navigates to `https://rockylinuxmerch.com/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)