### PR TITLE
Fix merch store URL and update translations

### DIFF
--- a/app/[locale]/contribute/shop/page.tsx
+++ b/app/[locale]/contribute/shop/page.tsx
@@ -23,7 +23,7 @@ const vendors = [
     name: "Muckles' U!",
     role: "Ships worldwide, based in US",
     imageUrl: "/images/shop/muckles-u.png",
-    link: "https://www.mucklesu.com/collections/rocky-linux",
+    link: "https://rockylinuxmerch.com/",
   },
   {
     name: "HELLOTUX",

--- a/docs/e2e/testing-patterns.md
+++ b/docs/e2e/testing-patterns.md
@@ -27,10 +27,11 @@ Radix Select portals its dropdown listbox to `document.body`. This means:
 **Solution:** Follow the `aria-controls` attribute from the combobox trigger to find its specific listbox by ID:
 
 ```typescript
-// After clicking to open the select
-const expandedPicker = page.locator(
-  '[role="combobox"][aria-label="Select language"][aria-expanded="true"]'
-);
+// After clicking to open the select — scope to the footer to avoid
+// hardcoding a translated aria-label
+const expandedPicker = page
+  .getByRole("contentinfo")
+  .locator('[role="combobox"][aria-expanded="true"]');
 const listboxId = await expandedPicker.getAttribute("aria-controls");
 const listbox = page.locator(`[id="${listboxId}"]`);
 ```
@@ -102,9 +103,9 @@ This requires adding `aria-label` to components that don't have visible labels. 
 Put component interaction helpers in `e2e/utils/PageUtils.ts` when the component is global (appears on every page) or will be tested from multiple spec files:
 
 ```typescript
-// e2e/utils/PageUtils.ts
+// e2e/utils/PageUtils.ts — scoped to footer so it works on all locales
 export const getLanguagePicker = (page: Page): Locator => {
-  return page.getByRole("combobox", { name: LANGUAGE_PICKER_LABEL });
+  return page.getByRole("contentinfo").getByRole("combobox");
 };
 
 export const openLanguagePicker = async (page: Page): Promise<Locator> => { ... };
@@ -191,9 +192,7 @@ page.getByRole("combobox", { name: "Select language" });
 page.getByRole("combobox", { name: "Select architecture" });
 ```
 
-**Exception:** Language switcher tests (`LanguageSwitcher.spec.ts`) navigate to non-English locales (`/fr-FR/`, `/de-DE/`, `/af-ZA/`) to verify locale switching and translated content. Once Crowdin populates translations for aria-label keys (e.g., `selectLanguage`), selectors using English accessible names will not match on non-English pages. If a language switcher test needs to interact with a localized component after navigating away from English, scope the selector by container or use a non-localized attribute instead of an accessible name.
-
-For tests that stay in the English locale, English constants (e.g., `LANGUAGE_PICKER_LABEL` in `PageUtils.ts`) remain correct.
+**Language picker:** The `getLanguagePicker` helper in `PageUtils.ts` scopes the combobox lookup to the footer (`contentinfo` role) instead of matching by accessible name. This avoids breaking when Crowdin translates the `selectLanguage` key — the footer only has one combobox, so the scoped query is unambiguous across all locales.
 
 ### `getAttribute()` Does Not Auto-Scroll
 

--- a/docs/e2e/testing-patterns.md
+++ b/docs/e2e/testing-patterns.md
@@ -31,6 +31,9 @@ Radix Select portals its dropdown listbox to `document.body`. This means:
 const picker = page.getByRole("contentinfo").getByRole("combobox");
 await picker.scrollIntoViewIfNeeded();
 const listboxId = await picker.getAttribute("aria-controls");
+if (!listboxId) {
+  throw new Error("Combobox is missing required aria-controls attribute");
+}
 
 await picker.click();
 const listbox = page.locator(`[id="${listboxId}"]`);

--- a/docs/e2e/testing-patterns.md
+++ b/docs/e2e/testing-patterns.md
@@ -24,20 +24,21 @@ Radix Select portals its dropdown listbox to `document.body`. This means:
 - `trigger.locator('[role="listbox"]')` will **not** work
 - `page.getByLabel('...').getByRole('listbox')` will **not** work (scopes to DOM children)
 
-**Solution:** Follow the `aria-controls` attribute from the combobox trigger to find its specific listbox by ID:
+**Solution:** Read the `aria-controls` attribute from the combobox trigger **before** clicking — Radix sets it even when the dropdown is closed. This avoids a re-query issue where Radix's portal overlay prevents Playwright from finding the trigger after the dropdown opens.
 
 ```typescript
-// After clicking to open the select — scope to the footer to avoid
-// hardcoding a translated aria-label
-const expandedPicker = page
-  .getByRole("contentinfo")
-  .locator('[role="combobox"][aria-expanded="true"]');
-const listboxId = await expandedPicker.getAttribute("aria-controls");
+// Read aria-controls before clicking — Radix sets it even when closed
+const picker = page.getByRole("contentinfo").getByRole("combobox");
+await picker.scrollIntoViewIfNeeded();
+const listboxId = await picker.getAttribute("aria-controls");
+
+await picker.click();
 const listbox = page.locator(`[id="${listboxId}"]`);
 ```
 
 This approach:
 
+- Reads `aria-controls` pre-click, avoiding post-click re-query issues
 - Uniquely identifies the listbox even if multiple selects exist on the page
 - Follows the actual ARIA relationship Radix establishes
 - Works regardless of where Radix portals the content

--- a/e2e/utils/PageUtils.ts
+++ b/e2e/utils/PageUtils.ts
@@ -1,9 +1,10 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
-const LANGUAGE_PICKER_LABEL = "Select language";
-
 /**
  * Returns a locator for the language picker combobox in the footer.
+ *
+ * Scoped to the footer (`contentinfo` role) so the lookup works regardless
+ * of the translated `aria-label` value.
  *
  * @param {Page} page - The Playwright page object.
  * @returns {Locator} A locator targeting the language picker combobox.
@@ -15,7 +16,7 @@ const LANGUAGE_PICKER_LABEL = "Select language";
  * ```
  */
 export const getLanguagePicker = (page: Page): Locator => {
-  return page.getByRole("combobox", { name: LANGUAGE_PICKER_LABEL });
+  return page.getByRole("contentinfo").getByRole("combobox");
 };
 
 /**
@@ -40,17 +41,17 @@ export const getLanguagePicker = (page: Page): Locator => {
  */
 export const openLanguagePicker = async (page: Page): Promise<Locator> => {
   const picker = getLanguagePicker(page);
-  await picker.click();
 
-  // Follow aria-controls to find the exact portaled listbox belonging
-  // to this combobox (Radix portals it to the body, so DOM traversal won't work)
-  const expandedPicker = page.locator(
-    `[role="combobox"][aria-label="${LANGUAGE_PICKER_LABEL}"][aria-expanded="true"]`
-  );
-  const listboxId = await expandedPicker.getAttribute("aria-controls");
+  // Read aria-controls before clicking — Radix sets it even when closed,
+  // and after the click Playwright may not be able to re-query the element
+  // within the footer (Radix portal overlay can interfere).
+  await picker.scrollIntoViewIfNeeded();
+  const listboxId = await picker.getAttribute("aria-controls");
   if (!listboxId) {
-    throw new Error("Language picker has no aria-controls after opening");
+    throw new Error("Language picker has no aria-controls attribute");
   }
+
+  await picker.click();
 
   const listbox = page.locator(`[id="${listboxId}"]`);
   await expect(listbox).toBeVisible();

--- a/e2e/utils/PageUtils.ts
+++ b/e2e/utils/PageUtils.ts
@@ -22,13 +22,15 @@ export const getLanguagePicker = (page: Page): Locator => {
 /**
  * Opens the language picker dropdown and returns a locator for its listbox.
  *
- * Clicks the combobox trigger, then follows the {@link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls aria-controls}
- * attribute to locate the exact portaled listbox. This is necessary because
- * Radix UI renders the listbox outside the trigger's DOM tree.
+ * Reads the {@link https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-controls aria-controls}
+ * attribute before clicking to locate the exact portaled listbox, then clicks
+ * to open the dropdown. Reading `aria-controls` pre-click avoids a re-query
+ * issue where Radix's portal overlay prevents Playwright from finding the
+ * trigger element after the dropdown opens.
  *
  * @param {Page} page - The Playwright page object.
  * @returns {Promise<Locator>} A locator targeting the opened listbox element.
- * @throws {Error} If the combobox has no `aria-controls` attribute after opening.
+ * @throws {Error} If the combobox has no `aria-controls` attribute.
  *
  * @see {@link https://github.com/radix-ui/primitives/issues/2288 Radix open-close race condition}
  * @see [Testing Patterns](../../docs/e2e/testing-patterns.md) for full context on Radix Select gotchas.

--- a/messages/af-ZA.json
+++ b/messages/af-ZA.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/ar-SA.json
+++ b/messages/ar-SA.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/ca-ES.json
+++ b/messages/ca-ES.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/cs-CZ.json
+++ b/messages/cs-CZ.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/da-DK.json
+++ b/messages/da-DK.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -7,7 +7,7 @@
       "description": "Die gesuchte Seite existiert nicht. Bitte überprüfen Sie die URL und versuchen Sie es erneut."
     },
     "close": "Schließen",
-    "selectLanguage": "Select language"
+    "selectLanguage": "Sprache auswählen"
   },
   "header": {
     "toggleTheme": "Design wechseln",
@@ -66,7 +66,7 @@
       "threads": "Themen",
       "youtube": "YouTube"
     },
-    "disclaimer": "Rocky Linux®️ ist die eingetragene Marke der Rocky Enterprise Software Foundation in den USA. Linux®️ ist die eingetragene Marke von Linus Torvalds in den USA und anderen Ländern. Red Hat Enterprise Linux, RHEL und CentOS sind Warenzeichen oder eingetragene Warenzeichen von Red Hat, Inc. oder Tochtergesellschaften in den USA und anderen Ländern, mit denen wir nicht verbunden sind, unterstützt von Red Hat, Inc."
+    "disclaimer": "Rocky Linux®️ ist die eingetragene Marke der Rocky Enterprise Software Foundation in den USA. Linux®️ ist die eingetragene Marke von Linus Torvalds in den USA und anderen Ländern. Red Hat Enterprise Linux, RHEL und CentOS sind Warenzeichen oder eingetragene Warenzeichen von Red Hat, Inc. oder Tochtergesellschaften in den USA und anderen Ländern, mit denen wir weder verbunden sind, noch unterstützt von Red Hat, Inc."
   },
   "home": {
     "hero": {
@@ -161,7 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Laden Sie hier die neuesten Rocky Linux Versionen herunter.",
-    "selectArchitecture": "Select architecture",
+    "selectArchitecture": "Architektur auswählen",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -6,7 +6,8 @@
       "title": "Nicht Gefunden",
       "description": "Die gesuchte Seite existiert nicht. Bitte überprüfen Sie die URL und versuchen Sie es erneut."
     },
-    "close": "Schließen"
+    "close": "Schließen",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Design wechseln",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Laden Sie hier die neuesten Rocky Linux Versionen herunter.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/el-GR.json
+++ b/messages/el-GR.json
@@ -6,7 +6,8 @@
       "title": "Δεν Βρέθηκε",
       "description": "Η σελίδα που ψάχνετε δεν υπάρχει. Ελέγξτε τη διεύθυνση URL και προσπαθήστε ξανά."
     },
-    "close": "Κλείσιμο"
+    "close": "Κλείσιμο",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Εναλλαγή θέματος",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Λήψη",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/es-ES.json
+++ b/messages/es-ES.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "La página que buscas no existe. Por favor, comprueba la URL e inténtalo de nuevo."
     },
-    "close": "Cerrar"
+    "close": "Cerrar",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Tema",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/fa-IR.json
+++ b/messages/fa-IR.json
@@ -6,7 +6,8 @@
       "title": "یافت نشد",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "دانلود",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/fi-FI.json
+++ b/messages/fi-FI.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -6,7 +6,8 @@
       "title": "Introuvable",
       "description": "La page que vous recherchez n'existe pas. Veuillez vérifier l'URL et réessayer."
     },
-    "close": "Fermer"
+    "close": "Fermer",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Changer de Thème",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Téléchargement",
     "description": "Téléchargez les dernières versions de Rocky Linux ici.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/fr-FR.json
+++ b/messages/fr-FR.json
@@ -7,7 +7,7 @@
       "description": "La page que vous recherchez n'existe pas. Veuillez vérifier l'URL et réessayer."
     },
     "close": "Fermer",
-    "selectLanguage": "Select language"
+    "selectLanguage": "Sélectionnez une langue"
   },
   "header": {
     "toggleTheme": "Changer de Thème",
@@ -66,7 +66,7 @@
       "threads": "Fils de Discussion",
       "youtube": "YouTube"
     },
-    "disclaimer": "Linux® est la marque déposée de Linus Torvalds aux États-Unis et dans d'autres pays. Red Hat Enterprise Linux, RHEL et CentOS sont des marques ou des marques déposées de Red Hat, Inc. ou de ses filiales aux États-Unis et dans d'autres pays. Nous ne sommes pas affiliés, approuvés ni sponsorisés par Red Hat, Inc."
+    "disclaimer": "Linux® est la marque déposée de Linus Torvalds aux États-Unis et dans d'autres pays. Red Hat Enterprise Linux, RHEL et CentOS sont des marques ou des marques déposées de Red Hat, Inc. ou de ses filiales aux États-Unis et dans d'autres pays. Nous ne sommes ni affiliés, ni approuvés, ni sponsorisés par Red Hat, Inc."
   },
   "home": {
     "hero": {
@@ -161,7 +161,7 @@
   "download": {
     "title": "Téléchargement",
     "description": "Téléchargez les dernières versions de Rocky Linux ici.",
-    "selectArchitecture": "Select architecture",
+    "selectArchitecture": "Sélectionnez une architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/he-IL.json
+++ b/messages/he-IL.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/hi-IN.json
+++ b/messages/hi-IN.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/hu-HU.json
+++ b/messages/hu-HU.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/id-ID.json
+++ b/messages/id-ID.json
@@ -6,7 +6,8 @@
       "title": "Tidak ditemukan",
       "description": "Halaman yang Anda cari tidak ada. Harap periksa URL dan coba lagi."
     },
-    "close": "Tutup"
+    "close": "Tutup",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Alih Tema",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Unduh",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -6,7 +6,8 @@
       "title": "Non Trovato",
       "description": "La pagina che state cercando non esiste. Controllare l'URL e riprovare."
     },
-    "close": "Chiudere"
+    "close": "Chiudere",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Cambia Tema",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Scaricate le ultime versioni di Rocky Linux qui.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/ka-GE.json
+++ b/messages/ka-GE.json
@@ -6,7 +6,8 @@
       "title": "ვერ ვიპოვე",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "დახურვა"
+    "close": "დახურვა",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "თემის გადართვა",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/ko-KR.json
+++ b/messages/ko-KR.json
@@ -6,7 +6,8 @@
       "title": "404 Not Found ",
       "description": "찾고 있는 페이지가 존재하지 않습니다. URL을 확인하고 다시 시도하세요."
     },
-    "close": "닫기"
+    "close": "닫기",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "테마 전환",
@@ -160,6 +161,7 @@
   "download": {
     "title": "다운로드",
     "description": "최신 로키 리눅스 설치",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/nl-NL.json
+++ b/messages/nl-NL.json
@@ -6,7 +6,8 @@
       "title": "Niet Gevonden",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Sluiten"
+    "close": "Sluiten",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Thema veranderen",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/no-NO.json
+++ b/messages/no-NO.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/pl-PL.json
+++ b/messages/pl-PL.json
@@ -6,7 +6,8 @@
       "title": "Nie znaleziono",
       "description": "Strona, której szukasz, nie istnieje. Sprawdź adres URL i spróbuj ponownie."
     },
-    "close": "Zamknij"
+    "close": "Zamknij",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Przełącz motyw",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Pobierz",
     "description": "Pobierz tutaj najnowsze wersje Rocky Linux.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -6,7 +6,8 @@
       "title": "Não Encontrada",
       "description": "A página que você está procurando não existe. Por favor, verifique a URL e tente novamente."
     },
-    "close": "Fechar"
+    "close": "Fechar",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Alternar Tema",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/pt-PT.json
+++ b/messages/pt-PT.json
@@ -6,7 +6,8 @@
       "title": "Não Encontrado",
       "description": "A página que procura não existe. Por favor, verifique a URL e tente novamente."
     },
-    "close": "Fechar"
+    "close": "Fechar",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Alternar Tema",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Descarregar",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/ro-RO.json
+++ b/messages/ro-RO.json
@@ -6,7 +6,8 @@
       "title": "Nu a fost găsit",
       "description": "Pagina pe care o căutați nu există. Vă rugăm să verificați adresa URL și să încercați din nou."
     },
-    "close": "Închide"
+    "close": "Închide",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Schimbă Tema",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Descărcare",
     "description": "Descarcă ultimele versiuni Rocky Linux de aici.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM64 (aarch64)",

--- a/messages/ru-RU.json
+++ b/messages/ru-RU.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/sr-SP.json
+++ b/messages/sr-SP.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM64 (aarch64)",

--- a/messages/sv-SE.json
+++ b/messages/sv-SE.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/ta-IN.json
+++ b/messages/ta-IN.json
@@ -6,7 +6,8 @@
       "title": "கிடைக்கவில்லை",
       "description": "நீங்கள் தேடும் பக்கம் இல்லை. முகவரியைச் சரிபார்த்து மீண்டும் முயற்சி செய்."
     },
-    "close": "மூடு"
+    "close": "மூடு",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "கருப்பொருள் நிலைமாற்று",
@@ -160,6 +161,7 @@
   "download": {
     "title": "பதிவிறக்கு",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/tr-TR.json
+++ b/messages/tr-TR.json
@@ -6,7 +6,8 @@
       "title": "Bulunamadı",
       "description": "Aradığınız sayfa mevcut değil. Lütfen URL'yi kontrol edin ve tekrar deneyin."
     },
-    "close": "Kapat"
+    "close": "Kapat",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Temayı Değiştir",
@@ -160,6 +161,7 @@
   "download": {
     "title": "İndir",
     "description": "En son Rocky Linux sürümlerini buradan indirin.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/uk-UA.json
+++ b/messages/uk-UA.json
@@ -6,7 +6,8 @@
       "title": "Не знайдено",
       "description": "\"Сторінки, яку ви шукаєте, не існує. Будь ласка, перевірте URL і спробуйте ще раз.\""
     },
-    "close": "Закрити"
+    "close": "Закрити",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Перемкнути тему",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Звантажити",
     "description": "Завантажте останні версії Rocky Linux тут.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/vi-VN.json
+++ b/messages/vi-VN.json
@@ -6,7 +6,8 @@
       "title": "Not Found",
       "description": "The page you are looking for does not exist. Please check the URL and try again."
     },
-    "close": "Close"
+    "close": "Close",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "Toggle Theme",
@@ -160,6 +161,7 @@
   "download": {
     "title": "Download",
     "description": "Download the latest Rocky Linux versions here.",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -6,7 +6,8 @@
       "title": "未找到",
       "description": "您正在查找的页面不存在。请检查URL，然后重试。"
     },
-    "close": "关闭"
+    "close": "关闭",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "切换主题",
@@ -160,6 +161,7 @@
   "download": {
     "title": "下载",
     "description": "在这里下载最新的 Rocky Linux 版本。",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -6,7 +6,8 @@
       "title": "您造訪的頁面不存在",
       "description": "您查詢的頁面不存在，請檢查網址後重試。"
     },
-    "close": "關閉"
+    "close": "關閉",
+    "selectLanguage": "Select language"
   },
   "header": {
     "toggleTheme": "切換主題",
@@ -160,6 +161,7 @@
   "download": {
     "title": "下載",
     "description": "點擊此處下載最新版Rocky Linux 。",
+    "selectArchitecture": "Select architecture",
     "tabs": {
       "x86_64": "AMD/Intel (x86_64)",
       "aarch64": "ARM (aarch64)",


### PR DESCRIPTION
## Summary
- Fix broken Muckles merch store link — old URL redirected away from Rocky Linux collection, now points to `https://rockylinuxmerch.com/` (#282)
- Fix E2E language picker selectors to work with translated aria-labels (#280)
- Update translations across 34 locales via Crowdin (#278, #279)

🤖 Generated with [Claude Code](https://claude.com/claude-code)