### PR TITLE
fix: remove dead riscv64 cloud image CHECKSUM URL (#326)

### DIFF
--- a/data/downloads.json
+++ b/data/downloads.json
@@ -468,9 +468,6 @@
               "baseOs": "https://download.rockylinux.org/pub/rocky/10/BaseOS/riscv64/",
               "archived": "https://dl.rockylinux.org/vault/rocky"
             },
-            "cloudImages": {
-              "checksum": "https://dl.rockylinux.org/pub/rocky/10/images/riscv64/CHECKSUM"
-            },
             "visionfive2Images": {
               "checksum": "https://dl.rockylinux.org/vault/rocky/10.0/images/riscv64/Rocky-10-VisionFive2-latest.riscv64.tar.xz.CHECKSUM"
             }


### PR DESCRIPTION
## Summary

The riscv64 entry in `data/downloads.json` had a stranded `links.cloudImages.checksum` pointing at `https://dl.rockylinux.org/pub/rocky/10/images/riscv64/CHECKSUM`, which now 404s after the 10.2 GA release. This caused the **Check Download URLs** workflow (daily cron + on `downloads.json` changes) to fail and auto-file issue #326.

The entry has been orphaned since 2025-08-13 (commit `6bacc5b`), when the matching `downloadOptions.cloudImages.qcow2` was removed for riscv64. The download UI guards the cloud-images card on the presence of `downloadOptions.cloudImages`, so this link was never actually rendered — it was dead data the URL checker still pinged.

This PR removes the orphaned block (3 lines). No other riscv64 links are touched; the `visionfive2Images` checksum is intact.

Fixes #326