### PR TITLE
Release: remove dead riscv64 cloud image CHECKSUM URL (#326)

### DIFF
--- a/data/downloads.json
+++ b/data/downloads.json
@@ -468,9 +468,6 @@
               "baseOs": "https://download.rockylinux.org/pub/rocky/10/BaseOS/riscv64/",
               "archived": "https://dl.rockylinux.org/vault/rocky"
             },
-            "cloudImages": {
-              "checksum": "https://dl.rockylinux.org/pub/rocky/10/images/riscv64/CHECKSUM"
-            },
             "visionfive2Images": {
               "checksum": "https://dl.rockylinux.org/vault/rocky/10.0/images/riscv64/Rocky-10-VisionFive2-latest.riscv64.tar.xz.CHECKSUM"
             }


### PR DESCRIPTION
## Summary

Promotes the fix from #327 to production.

Removes the orphaned `links.cloudImages.checksum` entry for riscv64 in `data/downloads.json`, which pointed at `https://dl.rockylinux.org/pub/rocky/10/images/riscv64/CHECKSUM` and began returning 404 after the 10.2 GA release. The entry had no matching `downloadOptions.cloudImages`, so it was never rendered in the UI — it only caused the Check Download URLs workflow to fail.

This is the sole change between `develop` and `main` (1 file, 3 deletions).

Fixes #326