### PR TITLE
fix(ci): run npm ci with --ignore-scripts to stop 6h hang (#329)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,11 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm ci
+        # --ignore-scripts: skip install lifecycle scripts (postinstall news
+        # clone, prepare → husky + playwright install). `playwright install`
+        # is unbounded and hangs CI for the full 6h job timeout (issue #329);
+        # none of these are needed to lint.
+        run: npm ci --ignore-scripts
       - name: Run ESLint
         run: npm run lint
 
@@ -46,7 +50,10 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm ci
+        # --ignore-scripts: skip install lifecycle scripts that hang CI (#329).
+        # News content is still fetched: `npm run build` runs the `prebuild`
+        # script (scripts/fetch-news-content.mjs) before `next build`.
+        run: npm ci --ignore-scripts
       - name: Cache Next.js build
         uses: actions/cache@v5
         with:
@@ -82,7 +89,9 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm ci
+        # --ignore-scripts: skip install lifecycle scripts that hang CI (#329).
+        # Unit tests need neither news content, husky, nor browsers.
+        run: npm ci --ignore-scripts
       - name: Run Unit Tests
         run: npm run test
 
@@ -109,7 +118,11 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: npm ci
+        # --ignore-scripts: skip install lifecycle scripts that hang CI (#329).
+        # Browsers are installed by the explicit "Install Playwright Browsers"
+        # step below, and `npm start` serves the prebuilt .next artifact (news
+        # content is already baked into the static pages at build time).
+        run: npm ci --ignore-scripts
       - name: Download build artifact
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## What & why

Fixes #329. CI jobs hang on the `Install Dependencies` (`npm ci`) step for the full **6-hour** GitHub Actions timeout and then get cancelled, leaving `lint` / `build` / `test` showing as `skipped`. This hits every PR that changes `package-lock.json` (Dependabot bumps, etc.).

**Root cause:** `npm ci` runs the `package.json` install lifecycle scripts:

```
postinstall : node scripts/fetch-news-content.mjs   # bounded — 120s timeout
prepare     : husky && playwright install            # UNBOUNDED — hangs
```

The job log shows Chromium downloading to 100% of 167.3 MiB, after which `playwright install` stalls indefinitely. It only surfaces on lockfile-change PRs because the `Install Dependencies` step is gated on a `node_modules` cache miss keyed by `hashFiles('package-lock.json')` — normal pushes hit the cache, skip `npm ci`, and never run the scripts. The bug has been latent the whole time.

## The change

Add `--ignore-scripts` to all four `npm ci` invocations. The lifecycle scripts aren't needed during install:

- **lint / test** — need neither news content, husky, nor browsers.
- **build** — its `prebuild` script still fetches news before `next build`, so nothing is lost.
- **e2e** — installs browsers via its existing explicit `npx playwright install` step, and `npm start` serves the prebuilt `.next` artifact (news is baked into the static pages at build time; the normal cache-hit path already runs e2e without fetching news).

`husky` is also pure dead weight in CI. Net effect: the hang is gone and every job skips a redundant browser download.

## Test plan

- [ ] All CI jobs complete (no 6h hang on `Install Dependencies`).
- [ ] `build` job produces the artifact with news content present (via `prebuild`).
- [ ] `e2e` job passes against the prebuilt artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
