### PR TITLE
chore(deps): patch brace-expansion + postcss advisories, drop unused tailwindcss-animate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "remark-rehype": "^11.1.2",
         "rss": "^1.2.2",
         "tailwind-merge": "^3.5.0",
-        "tailwindcss-animate": "^1.0.7",
         "typescript": "5.9.3",
         "unified": "^11.0.5",
         "vaul": "^1.1.2",
@@ -5853,9 +5852,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11710,9 +11709,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -11880,34 +11879,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-addon-api": {
@@ -12487,10 +12458,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.11",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.11.tgz",
-      "integrity": "sha512-5dDj8+lmvA8XB78SmzGI8NlQoksv7IfutGWeVZxiixHbO+p4LDPT3wuG/D9sM/wrjZZ9I+Siy/e117vbFPxSZg==",
-      "dev": true,
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -12507,7 +12477,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -13916,16 +13886,8 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tailwindcss-animate": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
-      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders"
-      }
     },
     "node_modules/tapable": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "remark-rehype": "^11.1.2",
     "rss": "^1.2.2",
     "tailwind-merge": "^3.5.0",
-    "tailwindcss-animate": "^1.0.7",
     "typescript": "5.9.3",
     "unified": "^11.0.5",
     "vaul": "^1.1.2",
@@ -93,6 +92,7 @@
     "tailwindcss": "^4.2.1"
   },
   "overrides": {
-    "glob": "^13"
+    "glob": "^13",
+    "postcss": "$postcss"
   }
 }


### PR DESCRIPTION
## What & why

Dependency housekeeping, part of a larger maintenance pass tracked in #332.

### Security (both moderate advisories resolved)
- **`brace-expansion` DoS** (GHSA-jxxr-4gwj-5jf2) — `npm audit fix` bumps
  5.0.5 → 5.0.6.
- **`postcss` XSS** (GHSA-qx2v-qp2m-jg93) — the vulnerable copy is `postcss@8.4.31`
  pinned inside `next` (range `<8.5.10`). npm's only auto-remedy is a Next
  downgrade, so instead an `overrides: { "postcss": "$postcss" }` entry forces
  the nested copy to match the top-level `postcss` (8.5.15) — a semver-compatible
  minor bump. `npm audit` now reports **0 vulnerabilities**.

### Cleanup
- **Drop `tailwindcss-animate`** — unused. No references in CSS or TS; Tailwind v4
  loads plugins via `@plugin` in `globals.css`, where only `@tailwindcss/typography`
  is wired.

Verified locally: production build, lint, and unit tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
