### PR TITLE
release: branding favicon fix (unblock client navigation)

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -33,7 +33,10 @@ export async function generateMetadata({
 
   return {
     title,
-    icons: { icon: "/favicon.png" },
+    // The favicon is rendered by <BrandedLogo> (a client component) so it can
+    // reflect date-based scheduled branding without a redeploy. It is the sole
+    // source of the favicon — a second icon here would compete with that link
+    // in <head> and could win based on document order.
     description,
     alternates: {
       ...alternatesForPath(locale, "/"),

--- a/components/BrandedLogo.tsx
+++ b/components/BrandedLogo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import Logo, { LogoWordmark } from "@/components/Logo";
 import { getActiveBranding } from "@/utils/branding";
 import {
@@ -11,37 +11,43 @@ import {
 } from "@/components/ui/tooltip";
 import brandingSchedule from "@/data/branding-schedule.json";
 
+/** Default favicon used when no scheduled branding is active. */
+const DEFAULT_FAVICON = "/favicon.png";
+
 const BrandedLogo = () => {
   const activeBranding = useMemo(() => getActiveBranding(brandingSchedule), []);
 
-  useEffect(() => {
-    if (!activeBranding) return;
+  /*
+    Render the favicon link declaratively so React 19 hoists it into <head>
+    and reconciles it across client-side navigations. The previous approach
+    mutated document.head imperatively in a useEffect (removing/appending
+    <link> nodes), which corrupted Next.js's head reconciliation and broke
+    client-side navigation — the URL changed but content and <title> stayed
+    stale, so links appeared to require a second click.
 
-    const updateFavicon = () => {
-      const existingIcons = document.querySelectorAll(
-        "link[rel='icon'], link[rel='shortcut icon']"
-      );
-      existingIcons.forEach((icon) => icon.remove());
-
-      const link = document.createElement("link");
-      link.rel = "icon";
-      link.href = activeBranding.favicon;
-      document.head.appendChild(link);
-    };
-
-    // Run immediately and also after a brief delay to handle
-    // Next.js head streaming that may re-add the default favicon
-    updateFavicon();
-    const timeout = setTimeout(updateFavicon, 100);
-    return () => clearTimeout(timeout);
-  }, [activeBranding]);
+    This is the single source of truth for the favicon (the root layout no
+    longer sets one), so there is exactly one <link rel="icon"> and no
+    ordering ambiguity between a default and a branded icon.
+  */
+  const favicon = (
+    <link
+      rel="icon"
+      href={activeBranding?.favicon ?? DEFAULT_FAVICON}
+    />
+  );
 
   if (!activeBranding) {
-    return <Logo />;
+    return (
+      <>
+        {favicon}
+        <Logo />
+      </>
+    );
   }
 
   return (
     <TooltipProvider>
+      {favicon}
       <Tooltip>
         <TooltipTrigger asChild>
           <svg

--- a/components/__tests__/BrandedLogo.test.tsx
+++ b/components/__tests__/BrandedLogo.test.tsx
@@ -1,0 +1,93 @@
+import { render } from "test-utils";
+
+import BrandedLogo from "../BrandedLogo";
+import { getActiveBranding } from "@/utils/branding";
+
+// Control which branding (if any) is active without depending on the system
+// clock or the real schedule.
+jest.mock("@/utils/branding", () => ({
+  getActiveBranding: jest.fn(),
+}));
+
+const mockedGetActiveBranding = getActiveBranding as jest.MockedFunction<
+  typeof getActiveBranding
+>;
+
+const prideEvent = {
+  name: "Pride Month",
+  startDate: "2026-06-01",
+  endDate: "2026-06-30",
+  icon: "/images/logos/pride.png",
+  favicon: "/images/logos/pride_favicon.png",
+  tooltip: "The Rocky Linux project recognizes LGBTQ Pride Month.",
+  recurring: true,
+};
+
+const faviconLinks = () =>
+  Array.from(
+    document.head.querySelectorAll<HTMLLinkElement>("link[rel='icon']")
+  ).map((link) => link.getAttribute("href"));
+
+afterEach(() => {
+  mockedGetActiveBranding.mockReset();
+  // React hoists <link> tags into <head>; clear them between tests.
+  document.head
+    .querySelectorAll("link[rel='icon']")
+    .forEach((link) => link.remove());
+});
+
+describe("BrandedLogo", () => {
+  describe("when no branding is active", () => {
+    beforeEach(() => {
+      mockedGetActiveBranding.mockReturnValue(null);
+    });
+
+    it("renders the default favicon link", () => {
+      render(<BrandedLogo />);
+      expect(faviconLinks()).toEqual(["/favicon.png"]);
+    });
+
+    it("does not render a branded logo image", () => {
+      const { container } = render(<BrandedLogo />);
+      expect(container.querySelector("image")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when branding is active", () => {
+    beforeEach(() => {
+      mockedGetActiveBranding.mockReturnValue(prideEvent);
+    });
+
+    it("renders the active branding favicon as the only icon link", () => {
+      render(<BrandedLogo />);
+      expect(faviconLinks()).toEqual([prideEvent.favicon]);
+    });
+
+    it("renders the branded logo image", () => {
+      const { container } = render(<BrandedLogo />);
+      expect(container.querySelector("image")).toHaveAttribute(
+        "href",
+        prideEvent.icon
+      );
+    });
+  });
+
+  // Regression guard for the client-navigation bug: the favicon must be
+  // rendered declaratively (so React reconciles it across navigations), not
+  // mutated onto document.head via a side effect. A declarative <link> is
+  // present after render with no manual appendChild to the document head.
+  it("renders the favicon link without imperatively mutating document.head", () => {
+    mockedGetActiveBranding.mockReturnValue(prideEvent);
+    const appendChild = jest.spyOn(document.head, "appendChild");
+    render(<BrandedLogo />);
+
+    expect(faviconLinks()).toEqual([prideEvent.favicon]);
+    // The favicon must not be appended to <head> imperatively (the old bug).
+    const iconAppends = appendChild.mock.calls.filter(
+      ([node]) =>
+        node instanceof HTMLLinkElement && node.getAttribute("rel") === "icon"
+    );
+    expect(iconAppends).toHaveLength(0);
+    appendChild.mockRestore();
+  });
+});

--- a/e2e/BrandedLogo.spec.ts
+++ b/e2e/BrandedLogo.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { expectDownloadPage } from "./utils/PageAssertions";
 
 /**
  * Scheduled branding (see `data/branding-schedule.json`) swaps the logo icon
@@ -7,9 +8,13 @@ import { test, expect, type Page } from "@playwright/test";
  * clock API to pin "now" to a date inside and outside the Pride Month range
  * without touching the system clock.
  *
- * The favicon swap is the piece unit tests can't cover: it's an imperative
- * `<link rel="icon">` mutation in BrandedLogo's useEffect, not part of React's
- * render tree. These tests assert it actually lands in a real browser.
+ * BrandedLogo renders the favicon declaratively (`<link rel="icon">` in the
+ * render tree) so React reconciles it across client-side navigations. An
+ * earlier version mutated `document.head` imperatively in a useEffect, which
+ * corrupted Next.js head reconciliation and broke client navigation — the URL
+ * changed but the page content and <title> stayed stale, so links appeared to
+ * need a second click. These tests assert the favicon lands in a real browser
+ * AND that navigation still commits on a single click while branding is active.
  */
 
 // Mid-month / midday so the assertion holds regardless of the browser timezone.
@@ -27,9 +32,12 @@ const headerLogoImage = (page: Page) =>
 const headerLogoDefaultIcon = (page: Page) =>
   page.getByRole("banner").locator("svg path[fill='#10B981']");
 
-/** The favicon `<link>` the effect points at the Pride favicon. */
+/** The favicon `<link>` pointing at the Pride favicon. */
 const prideFavicon = (page: Page) =>
   page.locator("link[rel='icon'][href*='pride_favicon']");
+
+/** Every `<link rel="icon">` in the document head. */
+const faviconLinks = (page: Page) => page.locator("link[rel='icon']");
 
 test.describe("Scheduled branding logo", () => {
   test("swaps the logo icon and favicon during an active period", async ({
@@ -44,8 +52,37 @@ test.describe("Scheduled branding logo", () => {
     await expect(headerLogoImage(page)).toHaveAttribute("href", /pride\.png/);
     await expect(headerLogoDefaultIcon(page)).toHaveCount(0);
 
-    // The effect replaces the favicon link in <head>.
+    // The favicon link in <head> points at the Pride favicon, and it is the
+    // only icon link — the root layout no longer renders a competing default.
     await expect(prideFavicon(page)).toHaveCount(1);
+    await expect(faviconLinks(page)).toHaveCount(1);
+  });
+
+  test("navigates on a single click while branding is active", async ({
+    page,
+  }) => {
+    // Regression: the imperative favicon mutation used to break client-side
+    // navigation while branding was active, so a link needed two clicks.
+    await page.clock.setFixedTime(DURING_PRIDE);
+    await page.goto("/");
+
+    // Confirm branding is actually active for this run.
+    await expect(prideFavicon(page)).toHaveCount(1);
+
+    await page
+      .getByRole("region", { name: /community way/i })
+      .getByRole("link", { name: "Download" })
+      .click();
+
+    // A single click must commit the navigation: URL, <title>, and content.
+    await expectDownloadPage(page);
+    await expect(
+      page.getByRole("region", { name: /community way/i })
+    ).toHaveCount(0);
+
+    // The favicon survives the client navigation as the single icon link.
+    await expect(prideFavicon(page)).toHaveCount(1);
+    await expect(faviconLinks(page)).toHaveCount(1);
   });
 
   test("uses the default logo and favicon outside any active period", async ({
@@ -58,7 +95,10 @@ test.describe("Scheduled branding logo", () => {
     await expect(headerLogoDefaultIcon(page)).toBeVisible();
     await expect(headerLogoImage(page)).toHaveCount(0);
 
-    // The effect early-returns, so the Pride favicon is never injected.
+    // No branding active: the Pride favicon is never used, and the only icon
+    // link is the default favicon.
     await expect(prideFavicon(page)).toHaveCount(0);
+    await expect(faviconLinks(page)).toHaveCount(1);
+    await expect(faviconLinks(page)).toHaveAttribute("href", "/favicon.png");
   });
 });

--- a/e2e/LanguageSwitcher.spec.ts
+++ b/e2e/LanguageSwitcher.spec.ts
@@ -125,10 +125,16 @@ test.describe("Language Switcher", () => {
 
       await page.waitForURL(/\/fr-FR/);
 
-      const cookies = await context.cookies();
-      const localeCookie = cookies.find((c) => c.name === "NEXT_LOCALE");
-      expect(localeCookie).toBeDefined();
-      expect(localeCookie!.value).toBe("fr-FR");
+      // The cookie is written client-side just before a full-page navigation,
+      // and the next-intl middleware may also set it via the server response.
+      // Poll rather than reading once so a single sample taken mid-reload
+      // (before the cookie is committed) doesn't cause a flake.
+      await expect
+        .poll(async () => {
+          const cookies = await context.cookies();
+          return cookies.find((c) => c.name === "NEXT_LOCALE")?.value;
+        })
+        .toBe("fr-FR");
     });
   });
 

--- a/utils/__tests__/branding.test.ts
+++ b/utils/__tests__/branding.test.ts
@@ -1,6 +1,16 @@
 import { getActiveBranding } from "../branding";
 import type { BrandingSchedule } from "@/types/brandingTypes";
 
+/**
+ * Build a Date in local time. getActiveBranding compares recurring events
+ * using the local calendar (`now.getMonth()`/`now.getDate()`), so tests must
+ * construct dates in local time too. `new Date("2026-06-01")` parses as UTC
+ * midnight, which lands on the previous day in timezones behind UTC and makes
+ * the boundary assertions fail anywhere other than a UTC machine (e.g. CI).
+ */
+const localDate = (year: number, month: number, day: number) =>
+  new Date(year, month - 1, day);
+
 const prideEvent = {
   name: "Pride Month",
   startDate: "2026-06-01",
@@ -32,7 +42,7 @@ const holidayEvent = {
 
 describe("getActiveBranding", () => {
   it("should return null for an empty schedule", () => {
-    expect(getActiveBranding([], new Date("2026-06-15"))).toBeNull();
+    expect(getActiveBranding([], localDate(2026, 6, 15))).toBeNull();
   });
 
   it("should use the current date when no date is provided", () => {
@@ -43,33 +53,33 @@ describe("getActiveBranding", () => {
     const schedule: BrandingSchedule = [prideEvent];
 
     it("should match during the active period", () => {
-      expect(getActiveBranding(schedule, new Date("2026-06-15"))).toEqual(
+      expect(getActiveBranding(schedule, localDate(2026, 6, 15))).toEqual(
         prideEvent
       );
     });
 
     it("should match on the start date", () => {
-      expect(getActiveBranding(schedule, new Date("2026-06-01"))).toEqual(
+      expect(getActiveBranding(schedule, localDate(2026, 6, 1))).toEqual(
         prideEvent
       );
     });
 
     it("should match on the end date", () => {
-      expect(getActiveBranding(schedule, new Date("2026-06-30"))).toEqual(
+      expect(getActiveBranding(schedule, localDate(2026, 6, 30))).toEqual(
         prideEvent
       );
     });
 
     it("should not match one day before the start date", () => {
-      expect(getActiveBranding(schedule, new Date("2026-05-31"))).toBeNull();
+      expect(getActiveBranding(schedule, localDate(2026, 5, 31))).toBeNull();
     });
 
     it("should not match one day after the end date", () => {
-      expect(getActiveBranding(schedule, new Date("2026-07-01"))).toBeNull();
+      expect(getActiveBranding(schedule, localDate(2026, 7, 1))).toBeNull();
     });
 
     it("should match the same month-day in a different year", () => {
-      expect(getActiveBranding(schedule, new Date("2030-06-15"))).toEqual(
+      expect(getActiveBranding(schedule, localDate(2030, 6, 15))).toEqual(
         prideEvent
       );
     });
@@ -79,13 +89,13 @@ describe("getActiveBranding", () => {
     const schedule: BrandingSchedule = [nonRecurringEvent];
 
     it("should match during the active period", () => {
-      expect(getActiveBranding(schedule, new Date("2026-06-23"))).toEqual(
+      expect(getActiveBranding(schedule, localDate(2026, 6, 23))).toEqual(
         nonRecurringEvent
       );
     });
 
     it("should not match the same dates in a different year", () => {
-      expect(getActiveBranding(schedule, new Date("2027-06-23"))).toBeNull();
+      expect(getActiveBranding(schedule, localDate(2027, 6, 23))).toBeNull();
     });
   });
 
@@ -93,34 +103,34 @@ describe("getActiveBranding", () => {
     const schedule: BrandingSchedule = [holidayEvent];
 
     it("should match in December within the range", () => {
-      expect(getActiveBranding(schedule, new Date("2026-12-25"))).toEqual(
+      expect(getActiveBranding(schedule, localDate(2026, 12, 25))).toEqual(
         holidayEvent
       );
     });
 
     it("should match in January within the range", () => {
-      expect(getActiveBranding(schedule, new Date("2027-01-03"))).toEqual(
+      expect(getActiveBranding(schedule, localDate(2027, 1, 3))).toEqual(
         holidayEvent
       );
     });
 
     it("should not match before the range in December", () => {
-      expect(getActiveBranding(schedule, new Date("2026-12-14"))).toBeNull();
+      expect(getActiveBranding(schedule, localDate(2026, 12, 14))).toBeNull();
     });
 
     it("should not match after the range in January", () => {
-      expect(getActiveBranding(schedule, new Date("2027-01-06"))).toBeNull();
+      expect(getActiveBranding(schedule, localDate(2027, 1, 6))).toBeNull();
     });
 
     it("should not match in a month outside the range", () => {
-      expect(getActiveBranding(schedule, new Date("2026-07-15"))).toBeNull();
+      expect(getActiveBranding(schedule, localDate(2026, 7, 15))).toBeNull();
     });
   });
 
   describe("priority ordering", () => {
     it("should return the first matching event when events overlap", () => {
       const schedule: BrandingSchedule = [prideEvent, nonRecurringEvent];
-      expect(getActiveBranding(schedule, new Date("2026-06-23"))).toEqual(
+      expect(getActiveBranding(schedule, localDate(2026, 6, 23))).toEqual(
         prideEvent
       );
     });


### PR DESCRIPTION
## Release: develop → main

Promotes the client-navigation fix to production.

### What's included
- **#344** — fix: render branding favicon declaratively to unblock client navigation

### Why this is time-sensitive
While scheduled branding is active (Pride Month, since June 1), `BrandedLogo` mutated `document.head` imperatively, which corrupted Next.js App Router head reconciliation. On production this means links (Download, News, etc.) require **two clicks** — the first changes the URL but the page content/title don't update. This release ships the fix.

The fix renders the favicon declaratively so React 19 manages it in `<head>` and reconciles it across navigations, with a single source of truth for the icon. Also includes a timezone fix for the branding unit tests and a flake fix for the LanguageSwitcher cookie e2e test.

Full detail in #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)