### PR TITLE
Release: content-repo images + e2e CI container fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,12 +137,30 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+      # Browser binaries come from the Playwright CDN (no apt), so this step
+      # fails loudly/fast on a network stall instead of hanging. Only the OS
+      # deps below touch apt — see that step for why they're split out.
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
+        run: npx playwright install
+      # Split from the browser download and run unconditionally (OS deps aren't
+      # in the browser cache). `playwright install --with-deps`/`install-deps`
+      # shells out to `sudo apt-get`, which on ubuntu-latest (24.04) hangs
+      # indefinitely with no output when either (a) a background
+      # unattended-upgrades job holds the dpkg lock, or (b) needrestart prompts
+      # interactively despite DEBIAN_FRONTEND (Launchpad #2004203). We stop the
+      # background apt jobs, suppress needrestart, and cap the step so a stall
+      # fails fast instead of eating the 60-minute job timeout.
       - name: Install Playwright OS deps
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps
+        timeout-minutes: 10
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          NEEDRESTART_MODE: a
+          NEEDRESTART_SUSPEND: "1"
+        run: |
+          sudo systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+          sudo systemctl kill --kill-who=all apt-daily.service 2>/dev/null || true
+          sudo -E npx playwright install-deps
       - name: Run Playwright tests
         run: npx playwright test
       - name: Upload Playwright report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,12 +137,26 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-      # Browser binaries come from the Playwright CDN (no apt), so this step
-      # fails loudly/fast on a network stall instead of hanging. Only the OS
-      # deps below touch apt — see that step for why they're split out.
+      # Browser binaries come from the Playwright CDN (no apt). The download can
+      # stall mid-stream from GitHub runners (playwright#34297, #20665) and
+      # `playwright install` has no overall timeout, so it would otherwise hang
+      # until the 60-minute job cap. Bound each attempt with `timeout` and retry
+      # with a fresh connection; a healthy download finishes in 1-3 min.
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install
+        timeout-minutes: 12
+        run: |
+          for attempt in 1 2 3; do
+            echo "::group::playwright install (attempt $attempt)"
+            if timeout 180 npx playwright install; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "attempt $attempt stalled or failed; retrying with a fresh connection"
+          done
+          echo "playwright install did not complete after 3 attempts" >&2
+          exit 1
       # Split from the browser download and run unconditionally (OS deps aren't
       # in the browser cache). `playwright install --with-deps`/`install-deps`
       # shells out to `sudo apt-get`, which on ubuntu-latest (24.04) hangs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,15 @@ jobs:
     needs: build
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    # Run in the official Playwright image so the browsers AND their OS deps are
+    # pre-baked — no runtime `playwright install` (CDN download stalls, see
+    # playwright#34297) and no `apt-get` (dpkg-lock/needrestart hangs on the
+    # ubuntu-latest runner). The tag MUST match the @playwright/test version in
+    # package.json so the bundled browsers match the test runner.
+    # --ipc=host: avoids Chromium crashing on the container's small /dev/shm.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      options: --ipc=host
     env:
       CI: true
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
@@ -119,62 +128,15 @@ jobs:
       - name: Install Dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
         # --ignore-scripts: skip install lifecycle scripts that hang CI (#329).
-        # Browsers are installed by the explicit "Install Playwright Browsers"
-        # step below, and `npm start` serves the prebuilt .next artifact (news
-        # content is already baked into the static pages at build time).
+        # Browsers ship in the container image, and `npm start` serves the
+        # prebuilt .next artifact (news content is already baked into the static
+        # pages at build time).
         run: npm ci --ignore-scripts
       - name: Download build artifact
         uses: actions/download-artifact@v8
         with:
           name: nextjs-build
           path: .next
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
-      - name: Cache Playwright Browsers
-        id: playwright-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-      # Browser binaries come from the Playwright CDN (no apt). The download can
-      # stall mid-stream from GitHub runners (playwright#34297, #20665) and
-      # `playwright install` has no overall timeout, so it would otherwise hang
-      # until the 60-minute job cap. Bound each attempt with `timeout` and retry
-      # with a fresh connection; a healthy download finishes in 1-3 min.
-      - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 12
-        run: |
-          for attempt in 1 2 3; do
-            echo "::group::playwright install (attempt $attempt)"
-            if timeout 180 npx playwright install; then
-              echo "::endgroup::"
-              exit 0
-            fi
-            echo "::endgroup::"
-            echo "attempt $attempt stalled or failed; retrying with a fresh connection"
-          done
-          echo "playwright install did not complete after 3 attempts" >&2
-          exit 1
-      # Split from the browser download and run unconditionally (OS deps aren't
-      # in the browser cache). `playwright install --with-deps`/`install-deps`
-      # shells out to `sudo apt-get`, which on ubuntu-latest (24.04) hangs
-      # indefinitely with no output when either (a) a background
-      # unattended-upgrades job holds the dpkg lock, or (b) needrestart prompts
-      # interactively despite DEBIAN_FRONTEND (Launchpad #2004203). We stop the
-      # background apt jobs, suppress needrestart, and cap the step so a stall
-      # fails fast instead of eating the 60-minute job timeout.
-      - name: Install Playwright OS deps
-        timeout-minutes: 10
-        env:
-          DEBIAN_FRONTEND: noninteractive
-          NEEDRESTART_MODE: a
-          NEEDRESTART_SUSPEND: "1"
-        run: |
-          sudo systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
-          sudo systemctl kill --kill-who=all apt-daily.service 2>/dev/null || true
-          sudo -E npx playwright install-deps
       - name: Run Playwright tests
         run: npx playwright test
       - name: Upload Playwright report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,11 @@ jobs:
       options: --ipc=host
     env:
       CI: true
+      # The container runs as root, but GitHub sets HOME=/github/home (owned by
+      # the image's pwuser). Firefox refuses to launch when $HOME isn't owned by
+      # the current user, so point HOME at root's own dir — this is the exact
+      # workaround Playwright's launch error recommends.
+      HOME: /root
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
       CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ Desktop.ini
 # News content (cloned at build time from rocky-linux/rockylinux.org-content)
 /news/
 /.content-tmp/
+# Images copied at build time from the content repo's /images
+/public/images/content/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -56,12 +56,6 @@ export default defineConfig({
       name: "Mobile Safari",
       use: { ...devices["iPhone 12"] },
     },
-
-    /* Test against branded browsers. */
-    {
-      name: "Google Chrome",
-      use: { ...devices["Desktop Chrome"], channel: "chrome" },
-    },
   ],
 
   /* Run your local dev server before starting the tests */

--- a/scripts/fetch-news-content.mjs
+++ b/scripts/fetch-news-content.mjs
@@ -51,6 +51,10 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..");
 const TMP_DIR = resolve(REPO_ROOT, ".content-tmp");
 const NEWS_DIR = resolve(REPO_ROOT, "news");
+// Images committed alongside the markdown in the content repo's /images are
+// copied here so posts can reference them as /images/content/<path>. Files
+// under /public are served from /, so /public/images/content/foo.png -> /images/content/foo.png.
+const CONTENT_IMAGES_DIR = resolve(REPO_ROOT, "public", "images", "content");
 
 // Resolve `git` to an absolute path from a set of system-owned directories so
 // the spawn cannot be hijacked by a binary in a user-writable directory the
@@ -193,6 +197,23 @@ if (!existsSync(clonedNewsDir)) {
 // the previous news/ intact if anything above fails.
 rmSync(NEWS_DIR, { recursive: true, force: true });
 renameSync(clonedNewsDir, NEWS_DIR);
+
+// Copy the content repo's images/ (if present) into public/images/content so
+// posts can link assets as /images/content/<path>. Optional: the content repo
+// won't always carry images, so a missing dir is not an error.
+const clonedImagesDir = resolve(TMP_DIR, "images");
+if (existsSync(clonedImagesDir)) {
+  rmSync(CONTENT_IMAGES_DIR, { recursive: true, force: true });
+  renameSync(clonedImagesDir, CONTENT_IMAGES_DIR);
+  log(
+    `public/images/content/ populated from ${redactedUrl}@${CONTENT_REPO_BRANCH}.`,
+  );
+} else {
+  // Stale assets from a previous build would otherwise linger and 404-mask.
+  rmSync(CONTENT_IMAGES_DIR, { recursive: true, force: true });
+  log(`no images/ in content repo — cleared public/images/content/.`);
+}
+
 rmSync(TMP_DIR, { recursive: true, force: true });
 
 log(`news/ populated from ${redactedUrl}@${CONTENT_REPO_BRANCH}.`);


### PR DESCRIPTION
Promotes `develop` to `main` (production).

## Included changes

**Feature — content-repo images on the site** (#348)
- Build-time fetch now copies the content repo's `images/` into `public/images/content/`, so blog posts can ship images committed alongside their markdown. Served from `/images/content/<path>`. Mirrors the existing atomic-swap pattern for `news/`; missing `images/` is a no-op and stale assets are cleared.

**CI — fix the e2e job hanging**
- e2e now runs inside `mcr.microsoft.com/playwright:v1.58.2-noble` (pinned to the `@playwright/test` version): browsers and OS deps are pre-baked, removing the runtime `playwright install` (CDN download stalls) and `apt-get` (dpkg-lock/needrestart hangs) that were hanging the job for up to the full 60-minute cap.
- `--ipc=host` so Chromium doesn't crash on the container's small `/dev/shm`; `HOME=/root` so Firefox launches under root-in-container.
- Dropped the redundant branded "Google Chrome" Playwright project (duplicated the `chromium` project); Chromium coverage retained.

All checks passed on the source PR (#349): build, lint, test, e2e (170 passed / 30 intentional viewport skips / 0 failed), SonarCloud, Vercel.
