### PR TITLE
fix: point Rocky 9 Raspberry Pi image to official build path

### DIFF
--- a/data/downloads.json
+++ b/data/downloads.json
@@ -230,14 +230,14 @@
               "cinnamon": "https://dl.rockylinux.org/pub/rocky/9/live/aarch64/Rocky-9-Cinnamon-aarch64-latest.iso"
             },
             "rpiImages": {
-              "currentVersion": "v9.2",
-              "download": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/RockyRpi_9.2.img.xz"
+              "currentVersion": "v9.8",
+              "download": "https://dl.rockylinux.org/pub/rocky/9/images/aarch64/Rocky-9-SBC-RaspberryPi.latest.aarch64.raw.xz"
             },
             "specializedDevices": [
               {
                 "name": "Raspberry Pi",
-                "download": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/RockyLinuxRpi_9-latest.img.xz",
-                "checksum": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/RockyLinuxRpi_9-latest.img.xz.sha256sum",
+                "download": "https://dl.rockylinux.org/pub/rocky/9/images/aarch64/Rocky-9-SBC-RaspberryPi.latest.aarch64.raw.xz",
+                "checksum": "https://dl.rockylinux.org/pub/rocky/9/images/aarch64/Rocky-9-SBC-RaspberryPi.latest.aarch64.raw.xz.CHECKSUM",
                 "readMe": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/README.txt"
               }
             ],
@@ -256,7 +256,7 @@
               "checksum": "https://dl.rockylinux.org/pub/rocky/9/images/aarch64/CHECKSUM"
             },
             "rpiImages": {
-              "checksum": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/RockyRpi_9.2.img.xz.sha256sum",
+              "checksum": "https://dl.rockylinux.org/pub/rocky/9/images/aarch64/Rocky-9-SBC-RaspberryPi.latest.aarch64.raw.xz.CHECKSUM",
               "readMe": "https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/README.txt"
             },
             "liveImages": {


### PR DESCRIPTION
## Summary

Fixes #351. The Rocky 9 Raspberry Pi download linked to a stale SIG/altarch image pinned at 9.2 (`RockyRpi_9.2.img.xz`). This switches it to the official Rocky build image, mirroring the structure already used for Rocky 10 in the same file.

**Old:** `https://dl.rockylinux.org/pub/sig/9/altarch/aarch64/images/RockyRpi_9.2.img.xz`
**New:** `https://dl.rockylinux.org/pub/rocky/9/images/aarch64/Rocky-9-SBC-RaspberryPi.latest.aarch64.raw.xz`

## Why this is correct

- The new path is the official Rocky build image (not a SIG side-build) and is current — the `.latest` symlink resolves to the 9.8 build (dated 2026-06-15).
- It exactly mirrors how Rocky 10 already references its RPi image in `data/downloads.json`.
- Verified the new download (200), its `.CHECKSUM` (200), and the README (200) all resolve.

## Changes

In `data/downloads.json` for Rocky Linux 9:
- `rpiImages.currentVersion`: `v9.2` → `v9.8`
- `rpiImages.download` → new official path
- `specializedDevices[Raspberry Pi].download` / `.checksum` → new path + `.CHECKSUM`
- `links.rpiImages.checksum` → new path `.CHECKSUM`

The `readMe` link (sig/9 README.txt) is unchanged and still resolves, matching the Rocky 10 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)